### PR TITLE
disable buttons in account.php

### DIFF
--- a/webroot/panel/modal/new_key.php
+++ b/webroot/panel/modal/new_key.php
@@ -30,7 +30,7 @@ action="<?php echo CONFIG["site"]["prefix"]; ?>/panel/account.php">
     <hr>
 
     <div id="key_paste">
-        <textarea placeholder="ssh-rsa AAARs1..." form="newKeyform" name="key" />
+        <textarea placeholder="ssh-rsa AAARs1..." form="newKeyform" name="key"></textarea>
         <input type="submit" value="Add Key" id="add-key" disabled />
     </div>
 


### PR DESCRIPTION
* disabled `key_paste`, `key_github` submit buttons by default
* added self-closing tags to some elements
* added hook to enable/disable `key_github`
* modified file-upload hook from https://github.com/UnityHPC/unity-web-portal/pull/324 to match style of the other 2 hooks 

https://github.com/user-attachments/assets/01d2c76d-ee93-461f-a6b6-34b709dce47d

