### PR TITLE
move message to front of log in error handler

### DIFF
--- a/resources/lib/UnityHTTPD.php
+++ b/resources/lib/UnityHTTPD.php
@@ -43,11 +43,17 @@ class UnityHTTPD
             error_log("$title: $message");
             return;
         }
-        $output = [
-            "message" => $message,
-            "REMOTE_USER" => $_SERVER["REMOTE_USER"] ?? null,
-            "REMOTE_ADDR" => $_SERVER["REMOTE_ADDR"] ?? null,
-        ];
+        $output = ["message" => $message];
+        if (!is_null($data)) {
+            try {
+                \jsonEncode($data);
+                $output["data"] = $data;
+            } catch (\JsonException $e) {
+                $output["data"] = "data could not be JSON encoded: " . $e->getMessage();
+            }
+        }
+        $output["REMOTE_USER"] = $_SERVER["REMOTE_USER"] ?? null;
+        $output["REMOTE_ADDR"] = $_SERVER["REMOTE_ADDR"] ?? null;
         if (!is_null($errorid)) {
             $output["errorid"] = $errorid;
         }
@@ -56,14 +62,6 @@ class UnityHTTPD
         } else {
             // newlines are bad for error log, but getTrace() is too verbose
             $output["trace"] = explode("\n", (new \Exception())->getTraceAsString());
-        }
-        if (!is_null($data)) {
-            try {
-                \jsonEncode($data);
-                $output["data"] = $data;
-            } catch (\JsonException $e) {
-                $output["data"] = "data could not be JSON encoded: " . $e->getMessage();
-            }
         }
         error_log("$title: " . \jsonEncode($output));
     }


### PR DESCRIPTION
before:
`[Thu Oct 30 18:51:20.996498 2025] [php:notice] [pid 1296970] [client ...:51993] internal server error: {"message":"An internal server error has occurred.","REMOTE_USER":"...","REMOTE_ADDR":"...","errorid":"6903b3a8f346c","trace":["#0 /srv/www/unity-web-2025-9-30/resources/lib/UnityHTTPD.php(127): UnityWebPortal\\\\lib\\\\UnityHTTPD::errorLog()","#1 /srv/www/unity-web-2025-9-30/resources/lib/UnityHTTPD.php(143): UnityWebPortal\\\\lib\\\\UnityHTTPD::internalServerError()","#2 [internal function]: UnityWebPortal\\\\lib\\\\UnityHTTPD::shutdown()","#3 {main}"],"data":{"error":{"type":1,"message":["Uncaught Exception: no such request: uid='...' request_for='...' in /srv/www/unity-web-2025-9-30/resources/lib/UnitySQL.php:106","Stack trace:","#0 /srv/www/unity-web-2025-9-30/resources/lib/UnityGroup.php(257): UnityWebPortal\\\\lib\\\\UnitySQL->getRequest()","#1 /srv/www/unity-web-2025-9-30/webroot/panel/pi.php(22): UnityWebPortal\\\\lib\\\\UnityGroup->approveUser()","#2 {main}","  thrown"],"file":"/srv/www/unity-web-2025-9-30/resources/lib/UnitySQL.php","line":106}}}`

after:
`[Thu Oct 30 18:51:20.996498 2025] [php:notice] [pid 1296970] [client ...:51993] internal server error: {"message":"An internal server error has occurred.","data":{"error":{"type":1,"message":["Uncaught Exception: no such request: uid='...' request_for='...' in /srv/www/unity-web-2025-9-30/resources/lib/UnitySQL.php:106","Stack trace:","#0 /srv/www/unity-web-2025-9-30/resources/lib/UnityGroup.php(257): UnityWebPortal\\\\lib\\\\UnitySQL->getRequest()","#1 /srv/www/unity-web-2025-9-30/webroot/panel/pi.php(22): UnityWebPortal\\\\lib\\\\UnityGroup->approveUser()","#2 {main}","  thrown"],"file":"/srv/www/unity-web-2025-9-30/resources/lib/UnitySQL.php","line":106}},"REMOTE_USER":"...","REMOTE_ADDR":"...","errorid":"6903b3a8f346c","trace":["#0 /srv/www/unity-web-2025-9-30/resources/lib/UnityHTTPD.php(127): UnityWebPortal\\\\lib\\\\UnityHTTPD::errorLog()","#1 /srv/www/unity-web-2025-9-30/resources/lib/UnityHTTPD.php(143): UnityWebPortal\\\\lib\\\\UnityHTTPD::internalServerError()","#2 [internal function]: UnityWebPortal\\\\lib\\\\UnityHTTPD::shutdown()","#3 {main}"]}`