### PR TITLE
curl throw exception

### DIFF
--- a/resources/autoload.php
+++ b/resources/autoload.php
@@ -28,6 +28,7 @@ require_once __DIR__ . "/lib/utils.php";
 require_once __DIR__ . "/lib/exceptions/NoDieException.php";
 require_once __DIR__ . "/lib/exceptions/SSOException.php";
 require_once __DIR__ . "/lib/exceptions/ArrayKeyException.php";
+require_once __DIR__ . "/lib/exceptions/CurlException.php";
 require_once __DIR__ . "/lib/exceptions/EntryNotFoundException.php";
 require_once __DIR__ . "/lib/exceptions/EnsureException.php";
 require_once __DIR__ . "/lib/exceptions/EncodingUnknownException.php";

--- a/resources/lib/UnityGithub.php
+++ b/resources/lib/UnityGithub.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace UnityWebPortal\lib;
+use UnityWebPortal\lib\exceptions\CurlException;
 
 class UnityGithub
 {
@@ -13,7 +14,11 @@ class UnityGithub
         curl_setopt($curl, CURLOPT_URL, $url);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
-        $keys = json_decode(curl_exec($curl), false);
+        $curl_output = curl_exec($curl);
+        if ($curl_output === false) {
+            throw new CurlException(curl_error($curl));
+        }
+        $keys = json_decode($curl_output, false);
         curl_close($curl);
 
         // normally returns array of objects each with a ->key attribute

--- a/resources/lib/exceptions/CurlException.php
+++ b/resources/lib/exceptions/CurlException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace UnityWebPortal\lib\exceptions;
+
+class CurlException extends \Exception {}

--- a/test/phpunit-bootstrap.php
+++ b/test/phpunit-bootstrap.php
@@ -19,6 +19,7 @@ require_once __DIR__ . "/../resources/lib/utils.php";
 require_once __DIR__ . "/../resources/lib/exceptions/NoDieException.php";
 require_once __DIR__ . "/../resources/lib/exceptions/SSOException.php";
 require_once __DIR__ . "/../resources/lib/exceptions/ArrayKeyException.php";
+require_once __DIR__ . "/../resources/lib/exceptions/CurlException.php";
 require_once __DIR__ . "/../resources/lib/exceptions/EntryNotFoundException.php";
 require_once __DIR__ . "/../resources/lib/exceptions/EnsureException.php";
 require_once __DIR__ . "/../resources/lib/exceptions/EncodingUnknownException.php";


### PR DESCRIPTION
demo: run tests that use the Github API while not connected to wifi

before:

<details>

```shell
$ docker exec -it docker-dev-web-1 bash -c 'cd /var/www/unity-web-portal && ./vendor/bin/phpunit ./test/unit/UnityGithubTest.php'
PHPUnit 12.4.2 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.6
Configuration: /var/www/unity-web-portal/phpunit.xml

...F                                                                4 / 4 (100%)

Time: 00:00.014, Memory: 18.00 MB

There was 1 failure:

1) UnityWebPortal\lib\UnityGithubTest::testGetGithubKeys#3 with data ('simonLeary42', ['ecdsa-sha2-nistp256 AAAAE2VjZ...xaTnk='])
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    0 => 'ecdsa-sha2-nistp256 AAAAE2VjZ...xaTnk='
 )

/var/www/unity-web-portal/test/unit/UnityGithubTest.php:33

FAILURES!
Tests: 4, Assertions: 4, Failures: 1.
```

</details>

after:

<details>

```shell
$ docker exec -it docker-dev-web-1 bash -c 'cd /var/www/unity-web-portal && ./vendor/bin/phpunit ./test/unit/UnityGithubTest.php'
PHPUnit 12.4.2 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.6
Configuration: /var/www/unity-web-portal/phpunit.xml

EEEE                                                                4 / 4 (100%)

Time: 00:00.013, Memory: 18.00 MB

There were 4 errors:

1) UnityWebPortal\lib\UnityGithubTest::testGetGithubKeys#0 with data ('', [])
UnityWebPortal\lib\exceptions\CurlException: Could not resolve host: api.github.com

/var/www/unity-web-portal/resources/lib/UnityGithub.php:19
/var/www/unity-web-portal/test/unit/UnityGithubTest.php:33

2) UnityWebPortal\lib\UnityGithubTest::testGetGithubKeys#1 with data ('asdfkljhasdflkjashdflkjashdflkasjd', [])
UnityWebPortal\lib\exceptions\CurlException: Could not resolve host: api.github.com

/var/www/unity-web-portal/resources/lib/UnityGithub.php:19
/var/www/unity-web-portal/test/unit/UnityGithubTest.php:33

3) UnityWebPortal\lib\UnityGithubTest::testGetGithubKeys#2 with data ('sheldor1510', [])
UnityWebPortal\lib\exceptions\CurlException: Could not resolve host: api.github.com

/var/www/unity-web-portal/resources/lib/UnityGithub.php:19
/var/www/unity-web-portal/test/unit/UnityGithubTest.php:33

4) UnityWebPortal\lib\UnityGithubTest::testGetGithubKeys#3 with data ('simonLeary42', ['ecdsa-sha2-nistp256 AAAAE2VjZ...xaTnk='])
UnityWebPortal\lib\exceptions\CurlException: Could not resolve host: api.github.com

/var/www/unity-web-portal/resources/lib/UnityGithub.php:19
/var/www/unity-web-portal/test/unit/UnityGithubTest.php:33

ERRORS!
Tests: 4, Assertions: 0, Errors: 4.
```

</details>