### PR TITLE
remove redis flush from tests

### DIFF
--- a/test/functional/PIBecomeApproveTest.php
+++ b/test/functional/PIBecomeApproveTest.php
@@ -67,8 +67,6 @@ class PIBecomeApproveTest extends TestCase
             $this->requestGroupCreation();
             $this->assertRequestedPIGroup(true);
 
-            $REDIS->flushAll(); // regression test: flush used to break requests
-
             $approve_uid = $SSO["user"];
             switchUser(...getAdminUser());
             $this->approveGroup($approve_uid);

--- a/test/functional/PiMemberApproveTest.php
+++ b/test/functional/PiMemberApproveTest.php
@@ -114,8 +114,6 @@ class PIMemberApproveTest extends TestCase
             $this->assertTrue($pi_group->requestExists($USER));
             $this->assertRequestedMembership(true, $gid);
 
-            $REDIS->flushAll(); // regression test: flush used to break requests
-
             $approve_uid = $SSO["user"];
             switchUser(...$pi_user_args);
             $this->approveUserByPI($approve_uid);
@@ -175,8 +173,6 @@ class PIMemberApproveTest extends TestCase
             $this->requestGroupMembership($pi_group->getOwner()->getMail());
             $this->assertTrue($pi_group->requestExists($USER));
             $this->assertRequestedMembership(true, $gid);
-
-            $REDIS->flushAll(); // regression test: flush used to break requests
 
             $approve_uid = $SSO["user"];
             switchUser(...getAdminUser());


### PR DESCRIPTION
creates an annoying problem in dev environment: https://github.com/UnityHPC/unity-web-portal/issues/328

no longer necessary since https://github.com/UnityHPC/unity-web-portal/pull/349