### PR TITLE
don't use BCC for single-recipient email

### DIFF
--- a/resources/lib/UnityMailer.php
+++ b/resources/lib/UnityMailer.php
@@ -113,7 +113,7 @@ class UnityMailer extends PHPMailer
                         $this->addBCC($addr);
                     }
                 } else {
-                    $this->AddAddress($recipients);
+                    $this->addAddress($recipients);
                 }
             }
         }


### PR DESCRIPTION
closes https://github.com/UnityHPC/unity-web-portal/issues/184

before (undisclosed recipients):

<img width="539" height="406" alt="image" src="https://github.com/user-attachments/assets/84d8eafb-c723-44e0-b951-5f213dd55bb4" />

after:

<img width="537" height="402" alt="image" src="https://github.com/user-attachments/assets/4bfced7f-120a-4560-81c0-16f4347ebd28" />