### PR TITLE
implement logic behind user flags

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -148,7 +148,11 @@ repos:
         entry: bash ./test/assert-exceptions-used.bash
         language: system
         files: ^resources/.*\.php$
-        exclude: ^resources/lib/UnityHTTPD\.php$
+        exclude: |
+          (?x)^(
+              ^resources/lib/UnityHTTPD\.php$|
+              ^resources/init\.php$|
+          )$
       - id: assert-forbidden-used
         name: Assert forbidden() is used
         entry: bash ./test/assert-forbidden-used.bash

--- a/LDAP.md
+++ b/LDAP.md
@@ -1,5 +1,10 @@
 Terminology:
 
 - **qualified user**: a user who is currently a PI or a member of at least one PI group
-- **native user**: a user who's entries exist in the OUs given in `config.ini`
-  - it is up to the administrator to ensure that no non-native entries exist in these OUs
+- **unqualified user**: inverse of qualified
+- **native user**: a user created by this account portal
+- **non-native user**: inverse of native
+  - users created for administrative purposes should not be mixed with native users in the LDAP OUs given in `config.ini` or else this account portal may get confused
+- **ghost user**: a user who is effectively deleted
+- **defunct group**: a PI group that was disbanded or that lost its owner
+  - memberuid attribute should be empty

--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ rm "$prod" && ln -s "$old" "$prod"
 
 ### Version-specific update instructions:
 
+### 1.6 -> 1.7
+
+- a new LDAP schema needs to be added:
+  ```shell
+  scp tools/docker-dev/identity/unity-cluster-schema.ldif root@your-ldap-server:/root/unity-cluster-schema.ldif
+  ssh root@your-ldap-server ldapadd -Y EXTERNAL -H ldapi:/// -f /root/unity-cluster-schema.ldif
+  ```
+
 ### 1.5 -> 1.6
 
 - the `[site]getting_started_url` option should be defined

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,6 +4,8 @@ parameters:
     - resources
     - webroot
     - test
+  excludePaths:
+    - test/Template.php
   ignoreErrors:
     # $this, $data comes from UnityMailer
     - messages:
@@ -33,6 +35,7 @@ parameters:
         - '#Negated boolean expression is always false\.#'
       paths:
         - test/functional/PiRemoveUserTest.php
+        - test/functional/LeaveGroupTest.php
         - test/phpunit-bootstrap.php
     - messages:
         - '#If condition is always false\.#'

--- a/resources/init.php
+++ b/resources/init.php
@@ -72,6 +72,20 @@ if (isset($_SERVER["REMOTE_USER"])) {
     $_SESSION["is_pi"] = $USER->isPI();
 
     $SQL->addLog("user_login", $OPERATOR->uid);
+
+    if ($USER->getFlag(UserFlag::LOCKED)) {
+        UnityHTTPD::forbidden("locked", "Your account is locked.");
+    }
+
+    if ($OPERATOR == $USER && $USER->getFlag(UserFlag::IDLELOCKED)) {
+        $USER->setFlag(UserFlag::IDLELOCKED, false);
+        UnityHTTPD::messageSuccess(
+            "Account Unlocked",
+            "Your account was previously locked due to inactivity.",
+        );
+    }
+
+    $USER->updateIsQualified(); // in case manual changes have been made to PI groups
 }
 
 $LOC_HEADER = __DIR__ . "/templates/header.php";

--- a/resources/lib/PosixGroup.php
+++ b/resources/lib/PosixGroup.php
@@ -68,4 +68,9 @@ class PosixGroup
     {
         return in_array($uid, $this->getMemberUIDs());
     }
+
+    public function overwriteMemberUIDs(array $uids): void
+    {
+        $this->entry->setAttribute("memberuid", $uids);
+    }
 }

--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -40,7 +40,7 @@ class UnityGroup extends PosixGroup
     public function requestGroup(?bool $send_mail_to_admins = null, bool $send_mail = true): void
     {
         $send_mail_to_admins ??= CONFIG["mail"]["send_pimesg_to_admins"];
-        if ($this->exists()) {
+        if ($this->exists() && !$this->getIsDefunct()) {
             return;
         }
         if ($this->SQL->accDeletionRequestExists($this->getOwner()->uid)) {
@@ -63,6 +63,44 @@ class UnityGroup extends PosixGroup
         }
     }
 
+    public function disband(bool $send_mail = true): void
+    {
+        $this->SQL->addLog("disband_pi_group", $this->gid);
+        $memberuids = $this->getMemberUIDs();
+        if ($send_mail) {
+            $member_attributes = $this->LDAP->getUsersAttributes($memberuids, ["mail"]);
+            $member_mails = array_map(fn($x) => $x["mail"][0], $member_attributes);
+            $this->MAILER->sendMail($member_mails, "group_disband", ["group_name" => $this->gid]);
+        }
+        $this->setIsDefunct(true);
+        if (count($memberuids) > 0) {
+            $this->entry->setAttribute("memberuid", []);
+        }
+        // TODO optimmize
+        // updateIsQualified() makes one LDAP query for each member
+        // if user is no longer in any PI group, disqualify them
+        foreach ($memberuids as $uid) {
+            $user = new UnityUser($uid, $this->LDAP, $this->SQL, $this->MAILER, $this->WEBHOOK);
+            $user->updateIsQualified($send_mail);
+        }
+    }
+
+    private function reinstate(bool $send_mail = true)
+    {
+        $this->SQL->addLog("reinstate_pi_group", $this->gid);
+        if ($send_mail) {
+            $this->MAILER->sendMail($this->getOwner()->getMail(), "group_reinstate", [
+                "group_name" => $this->gid,
+            ]);
+        }
+        $this->setIsDefunct(false);
+        $owner_uid = $this->getOwner()->uid;
+        if (!$this->memberUIDExists($owner_uid)) {
+            $this->addMemberUID($owner_uid);
+        }
+        $this->getOwner()->updateIsQualified($send_mail);
+    }
+
     /**
      * This method will create the group (this is what is executed when an admin approved the group)
      */
@@ -70,18 +108,21 @@ class UnityGroup extends PosixGroup
     {
         $uid = $this->getOwner()->uid;
         $request = $this->SQL->getRequest($uid, UnitySQL::REQUEST_BECOME_PI);
-        if ($this->exists()) {
-            return;
-        }
         \ensure($this->getOwner()->exists());
-        $this->init();
+        if (!$this->entry->exists()) {
+            $this->init();
+        } elseif ($this->getIsDefunct()) {
+            $this->reinstate();
+        } else {
+            throw new Exception("cannot approve group that already exists and is not defunct");
+        }
         $this->SQL->removeRequest($this->getOwner()->uid, UnitySQL::REQUEST_BECOME_PI);
         $this->SQL->addLog("approved_group", $this->getOwner()->uid);
         if ($send_mail) {
             $this->MAILER->sendMail($this->getOwner()->getMail(), "group_created");
         }
         // having your own group makes you qualified
-        $this->getOwner()->setFlag(UserFlag::QUALIFIED, true);
+        $this->getOwner()->updateIsQualified($send_mail);
     }
 
     /**
@@ -126,42 +167,6 @@ class UnityGroup extends PosixGroup
         }
     }
 
-    // /**
-    //  * This method will delete the group, either by admin action or PI action
-    //  */
-    // public function removeGroup($send_mail = true)
-    // {
-    //     // remove any pending requests
-    //     // this will silently fail if the request doesn't exist (which is what we want)
-    //     $this->SQL->removeRequests($this->gid);
-
-    //     // we don't need to do anything extra if the group is already deleted
-    //     if (!$this->exists()) {
-    //         return;
-    //     }
-
-    //     // first, we must record the users in the group currently
-    //     $users = $this->getGroupMembers();
-
-    //     // now we delete the ldap entry
-    //     $this->entry->ensureExists();
-    //     $this->entry->delete();
-
-    //     // Logs the change
-    //     $this->SQL->addLog("removed_group", $this->gid);
-
-    //     // send email to every user of the now deleted PI group
-    //     if ($send_mail) {
-    //         foreach ($users as $user) {
-    //             $this->MAILER->sendMail(
-    //                 $user->getMail(),
-    //                 "group_disband",
-    //                 array("group_name" => $this->gid)
-    //             );
-    //         }
-    //     }
-    // }
-
     /**
      * This method is executed when a user is approved to join the group
      * (either by admin or the group owner)
@@ -188,13 +193,7 @@ class UnityGroup extends PosixGroup
                 "org" => $new_user->getOrg(),
             ]);
         }
-        // being in a group makes you qualified
-        $new_user->setFlag(
-            UserFlag::QUALIFIED,
-            true,
-            doSendMail: $send_mail,
-            doSendMailAdmin: false,
-        );
+        $new_user->updateIsQualified($send_mail); // being in a group makes you qualified
     }
 
     public function denyUser(UnityUser $new_user, bool $send_mail = true): void
@@ -246,6 +245,8 @@ class UnityGroup extends PosixGroup
                 "org" => $new_user->getOrg(),
             ]);
         }
+        // if user is no longer in any PI group, disqualify them
+        $new_user->updateIsQualified($send_mail);
     }
 
     public function newUserRequest(UnityUser $new_user, bool $send_mail = true): void
@@ -329,7 +330,7 @@ class UnityGroup extends PosixGroup
         \ensure(!$this->entry->exists());
         $nextGID = $this->LDAP->getNextPIGIDNumber();
         $this->entry->create([
-            "objectclass" => UnityLDAP::POSIX_GROUP_CLASS,
+            "objectclass" => ["unityClusterPIGroup", "posixGroup", "top"],
             "gidnumber" => strval($nextGID),
             "memberuid" => [$owner->uid],
         ]);
@@ -384,5 +385,41 @@ class UnityGroup extends PosixGroup
             $attributes,
             $default_values,
         );
+    }
+
+    public function getIsDefunct(): bool
+    {
+        $value = $this->entry->getAttribute("isDefunct");
+        switch (count($value)) {
+            case 0:
+                return false;
+            case 1:
+                switch ($value[0]) {
+                    case "TRUE":
+                        return true;
+                    case "FALSE":
+                        return false;
+                    default:
+                        throw new \RuntimeException(
+                            sprintf(
+                                "unexpected value for isDefunct: '%s'. expected 'TRUE' or 'FALSE'.",
+                                $value[0],
+                            ),
+                        );
+                }
+            default:
+                throw new \RuntimeException(
+                    sprintf(
+                        "expected value of length 0 or 1, found value %s of length %s",
+                        jsonEncode($value),
+                        count($value),
+                    ),
+                );
+        }
+    }
+
+    public function setIsDefunct(bool $new_value): void
+    {
+        $this->entry->setAttribute("isDefunct", $new_value ? "TRUE" : "FALSE");
     }
 }

--- a/resources/lib/UnityOrg.php
+++ b/resources/lib/UnityOrg.php
@@ -37,7 +37,7 @@ class UnityOrg extends PosixGroup
         \ensure(!$this->entry->exists());
         $nextGID = $this->LDAP->getNextOrgGIDNumber();
         $this->entry->create([
-            "objectclass" => UnityLDAP::POSIX_GROUP_CLASS,
+            "objectclass" => ["posixGroup", "top"],
             "gidnumber" => strval($nextGID),
         ]);
     }

--- a/resources/mail/group_reinstate.php
+++ b/resources/mail/group_reinstate.php
@@ -1,0 +1,12 @@
+<?php
+
+// This template is sent to the group owner when that group is reinstated
+$this->Subject = "PI Group Reinstated"; ?>
+
+<p>Hello,</p>
+
+<p>
+Your PI group, <?php echo $data["group_name"]; ?>, has been reinstated on the UnityHPC Platform.
+</p>
+
+<p>If you believe this to be a mistake, please reply to this email</p>

--- a/resources/mail/user_flag_removed_admin.php
+++ b/resources/mail/user_flag_removed_admin.php
@@ -1,9 +1,9 @@
 <?php use UnityWebPortal\lib\UserFlag; ?>
 <?php switch ($data["flag"]):
 case UserFlag::QUALIFIED: ?>
-<?php $this->Subject = "User Dequalified"; ?>
+<?php $this->Subject = "User Disqualified"; ?>
 <p>Hello,</p>
-<p>User "<?php echo $data["user"] ?>" has been dequalified. </p>
+<p>User "<?php echo $data["user"] ?>" has been disqualified. </p>
 <?php break; ?>
 
 <?php /////////////////////////////////////////////////////////////////////////////////////////// ?>

--- a/test/Template.php
+++ b/test/Template.php
@@ -1,0 +1,18 @@
+<?php
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use TRegx\PhpUnit\DataProviders\DataProvider as TRegxDataProvider;
+
+class FoobarTest extends UnityWebPortalTestCase
+{
+    public static function provider(): TRegxDataProvider
+    {
+        return TRegxDataProvider::list("foo", "bar");
+    }
+
+    #[DataProvider("provider")]
+    public function testFoobar(string $x)
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/test/functional/IdleUnlockTest.php
+++ b/test/functional/IdleUnlockTest.php
@@ -1,0 +1,31 @@
+<?php
+use UnityWebPortal\lib\UserFlag;
+use UnityWebPortal\lib\UnityHTTPDMessageLevel;
+
+class IdleUnlockTest extends UnityWebPortalTestCase
+{
+    public function testIdleUnlock()
+    {
+        global $USER, $LDAP;
+        $this->switchUser("Admin");
+        $idle_locked_group = $LDAP->userFlagGroups["idlelocked"];
+        $members_before = $idle_locked_group->getMemberUIDs();
+        try {
+            $this->switchUser("IdleLocked");
+            $this->assertContains($USER->uid, $members_before);
+            $this->assertMessageExists(
+                UnityHTTPDMessageLevel::SUCCESS,
+                "/^Account Unlocked$/",
+                "/.*inactivity.*/",
+            );
+            $members_after = $idle_locked_group->getMemberUIDs();
+            $this->assertNotContains($USER->uid, $members_after);
+        } finally {
+            if (!$USER->getFlag(UserFlag::IDLELOCKED)) {
+                $USER->setFlag(UserFlag::IDLELOCKED, true);
+            }
+            $members_finally = $idle_locked_group->getMemberUIDs();
+            $this->assertContains($USER->uid, $members_finally);
+        }
+    }
+}

--- a/test/functional/LeaveGroupTest.php
+++ b/test/functional/LeaveGroupTest.php
@@ -1,0 +1,68 @@
+<?php
+use UnityWebPortal\lib\UnityUser;
+use UnityWebPortal\lib\UserFlag;
+use UnityWebPortal\lib\UnityGroup;
+
+class LeaveGroupTest extends UnityWebPortalTestCase
+{
+    public function testLeaveGroupDisqualified()
+    {
+        global $USER, $LDAP, $SQL, $MAILER, $WEBHOOK;
+        $this->switchUser("Normal");
+        $pi_gids = $USER->getPIGroupGIDs();
+        $this->assertEquals(1, count($pi_gids));
+        $gid = $pi_gids[0];
+        $pi_group = new UnityGroup($gid, $LDAP, $SQL, $MAILER, $WEBHOOK);
+        $this->assertTrue($pi_group->memberUIDExists($USER->uid));
+        $this->assertTrue($USER->getFlag(UserFlag::QUALIFIED));
+        try {
+            http_post(__DIR__ . "/../../webroot/panel/groups.php", [
+                "form_type" => "removePIForm",
+                "pi" => $gid,
+            ]);
+            $this->assertFalse($pi_group->memberUIDExists($USER->uid));
+            $this->assertFalse($USER->getFlag(UserFlag::QUALIFIED));
+        } finally {
+            if (!$pi_group->memberUIDExists($USER->uid)) {
+                $pi_group->newUserRequest($USER);
+                $pi_group->approveUser($USER);
+            }
+            $this->assertTrue($pi_group->memberUIDExists($USER->uid));
+            $this->assertTrue($USER->getFlag(UserFlag::QUALIFIED));
+        }
+    }
+
+    // if an admin goes messing around with LDAP entries by hand and also forgets to update the
+    // qualified users group, the portal should update the user's qualified status the next time
+    // they log in
+    public function testRemovedFromGroupManuallyDisqualifiedOnLogin()
+    {
+        global $USER, $LDAP, $SQL, $MAILER, $WEBHOOK;
+        $this->switchUser("Normal");
+        $pi_gids = $USER->getPIGroupGIDs();
+        $this->assertEquals(1, count($pi_gids));
+        $gid = $pi_gids[0];
+        $pi_group = new UnityGroup($gid, $LDAP, $SQL, $MAILER, $WEBHOOK);
+        $this->assertTrue($pi_group->memberUIDExists($USER->uid));
+        $this->assertTrue($USER->getFlag(UserFlag::QUALIFIED));
+        try {
+            $old_memberuids = $pi_group->getMemberUIDs();
+            $new_memberuids = array_values(
+                array_filter($old_memberuids, fn($x) => $x !== $USER->uid),
+            );
+            $pi_group_entry = $LDAP->getPIGroupEntry($pi_group->gid);
+            $pi_group_entry->setAttribute("memberuid", $new_memberuids);
+            $this->assertTrue($USER->getFlag(UserFlag::QUALIFIED));
+            session_write_close();
+            http_get(__DIR__ . "/../../resources/init.php");
+            $this->assertFalse($USER->getFlag(UserFlag::QUALIFIED));
+        } finally {
+            if (!$pi_group->memberUIDExists($USER->uid)) {
+                $pi_group->newUserRequest($USER);
+                $pi_group->approveUser($USER);
+            }
+            $this->assertTrue($pi_group->memberUIDExists($USER->uid));
+            $this->assertTrue($USER->getFlag(UserFlag::QUALIFIED));
+        }
+    }
+}

--- a/test/functional/PiDefunctTest.php
+++ b/test/functional/PiDefunctTest.php
@@ -1,0 +1,50 @@
+<?php
+
+class PiDefunctTest extends UnityWebPortalTestCase
+{
+    public function testGetDefunctSetDefunct()
+    {
+        global $USER, $LDAP;
+        $this->switchUser("NormalPI");
+        $pi_group = $USER->getPIGroup();
+        $entry = $LDAP->getPIGroupEntry($pi_group->gid);
+        $this->assertEquals([], $entry->getAttribute("isDefunct"));
+        try {
+            $pi_group->setIsDefunct(false);
+            $this->assertFalse($pi_group->getIsDefunct());
+            $pi_group->setIsDefunct(true);
+            $this->assertTrue($pi_group->getIsDefunct());
+            $entry->removeAttribute("isDefunct");
+            $this->assertFalse($pi_group->getIsDefunct());
+        } finally {
+            if ($entry->hasAttribute("isDefunct")) {
+                $entry->removeAttribute("isDefunct");
+            }
+        }
+    }
+
+    public function testPIMgmtShowsBothGroupsWithDefunctAttributeSetFalseAndUnset()
+    {
+        global $USER, $LDAP;
+        $this->switchUser("NormalPI");
+        $pi_group = $USER->getPIGroup();
+        $entry = $LDAP->getPIGroupEntry($pi_group->gid);
+        $this->assertEquals([], $entry->getAttribute("isDefunct"));
+        $this->assertStringContainsString(
+            $pi_group->gid,
+            http_get(__DIR__ . "/../../webroot/admin/pi-mgmt.php"),
+        );
+        try {
+            $pi_group->setIsDefunct(false);
+            $this->assertEquals(["FALSE"], $entry->getAttribute("isDefunct"));
+            $this->assertStringContainsString(
+                $pi_group->gid,
+                http_get(__DIR__ . "/../../webroot/admin/pi-mgmt.php"),
+            );
+        } finally {
+            if ($entry->hasAttribute("isDefunct")) {
+                $entry->removeAttribute("isDefunct");
+            }
+        }
+    }
+}

--- a/test/functional/PiDisbandTest.php
+++ b/test/functional/PiDisbandTest.php
@@ -1,0 +1,77 @@
+<?php
+use UnityWebPortal\lib\UserFlag;
+
+class PiDisbandTest extends UnityWebPortalTestCase
+{
+    public function testDisbandGroupByAdmin()
+    {
+        global $USER, $LDAP;
+        $this->switchUser("EmptyPIGroupOwner");
+        $pi_group = $USER->getPIGroup();
+        $memberuids_before = $pi_group->getMemberUIDs();
+        $this->assertFalse($pi_group->getIsDefunct());
+        $this->assertNotEmpty($pi_group->getMemberUIDs());
+        $this->assertTrue($pi_group->getOwner()->getFlag(UserFlag::QUALIFIED));
+        try {
+            $this->switchUser("Admin");
+            http_post(__DIR__ . "/../../webroot/admin/pi-mgmt.php", [
+                "form_type" => "disband",
+                "pi" => $pi_group->gid,
+            ]);
+            $this->assertTrue($pi_group->getIsDefunct());
+            $this->assertEmpty($pi_group->getMemberUIDs());
+            $this->assertFalse($pi_group->getOwner()->getFlag(UserFlag::QUALIFIED));
+        } finally {
+            $entry = $LDAP->getPIGroupEntry($pi_group->gid);
+            $entry->setAttribute("memberuid", $memberuids_before);
+            $entry->setAttribute("isDefunct", "FALSE");
+            $pi_group->getOwner()->setFlag(UserFlag::QUALIFIED, true);
+        }
+    }
+
+    public function testDisbandGroupByPI()
+    {
+        global $USER, $LDAP;
+        $this->switchUser("EmptyPIGroupOwner");
+        $pi_group = $USER->getPIGroup();
+        $memberuids_before = $pi_group->getMemberUIDs();
+        $this->assertFalse($pi_group->getIsDefunct());
+        $this->assertNotEmpty($pi_group->getMemberUIDs());
+        $this->assertTrue($pi_group->getOwner()->getFlag(UserFlag::QUALIFIED));
+        try {
+            http_post(__DIR__ . "/../../webroot/panel/pi.php", ["form_type" => "disband"]);
+            $this->assertTrue($pi_group->getIsDefunct());
+            $this->assertEmpty($pi_group->getMemberUIDs());
+            $this->assertFalse($pi_group->getOwner()->getFlag(UserFlag::QUALIFIED));
+        } finally {
+            $entry = $LDAP->getPIGroupEntry($pi_group->gid);
+            $entry->setAttribute("memberuid", $memberuids_before);
+            $entry->setAttribute("isDefunct", "FALSE");
+            $pi_group->getOwner()->setFlag(UserFlag::QUALIFIED, true);
+        }
+    }
+
+    public function testMemberBecomesUnqualified()
+    {
+        global $USER, $LDAP;
+        $this->switchUser("Blank");
+        $new_user = $USER;
+        $this->assertFalse($new_user->getFlag(UserFlag::QUALIFIED));
+        $this->switchUser("EmptyPIGroupOwner");
+        $pi_group = $USER->getPIGroup();
+        $memberuids_before = $pi_group->getMemberUIDs();
+        try {
+            $pi_group->newUserRequest($new_user);
+            $pi_group->approveUser($new_user);
+            $this->assertTrue($new_user->getFlag(UserFlag::QUALIFIED));
+            http_post(__DIR__ . "/../../webroot/panel/pi.php", ["form_type" => "disband"]);
+            $this->assertFalse($new_user->getFlag(UserFlag::QUALIFIED));
+        } finally {
+            $entry = $LDAP->getPIGroupEntry($pi_group->gid);
+            $entry->setAttribute("memberuid", $memberuids_before);
+            $entry->setAttribute("isDefunct", "FALSE");
+            $pi_group->getOwner()->setFlag(UserFlag::QUALIFIED, true);
+            $new_user->setFlag(UserFlag::QUALIFIED, false);
+        }
+    }
+}

--- a/test/functional/PiMemberApproveTest.php
+++ b/test/functional/PiMemberApproveTest.php
@@ -21,6 +21,7 @@ class PIMemberApproveTest extends UnityWebPortalTestCase
 
     private function approveUserByAdmin(string $uid, string $gid)
     {
+        global $USER;
         $this->switchUser("Admin");
         try {
             http_post(__DIR__ . "/../../webroot/admin/pi-mgmt.php", [

--- a/test/functional/ViewAsUserTest.php
+++ b/test/functional/ViewAsUserTest.php
@@ -8,8 +8,7 @@ class ViewAsUserTest extends UnityWebPortalTestCase
     public function _testViewAsUser(string $beforeNickname, string $afterNickname)
     {
         global $USER;
-        $this->switchUser($afterNickname);
-        $afterUid = $USER->uid;
+        $afterUid = self::$NICKNAME2UID[$afterNickname];
         $this->switchUser($beforeNickname);
         // $this->assertTrue($USER->getFlag(UserFlag::ADMIN));
         $beforeUid = $USER->uid;
@@ -64,5 +63,15 @@ class ViewAsUserTest extends UnityWebPortalTestCase
             "uid" => $adminUid,
         ]);
         $this->assertArrayNotHasKey("viewUser", $_SESSION);
+    }
+
+    public function testViewAsIdleLockedUserStillIdleLocked()
+    {
+        global $LDAP;
+        $idleLockedUID = self::$NICKNAME2UID["IdleLocked"];
+        $this->switchUser("Admin");
+        $this->assertContains($idleLockedUID, $LDAP->userFlagGroups["idlelocked"]->getMemberUIDs());
+        $this->_testViewAsUser("Admin", "IdleLocked");
+        $this->assertContains($idleLockedUID, $LDAP->userFlagGroups["idlelocked"]->getMemberUIDs());
     }
 }

--- a/test/functional/WorkerUpdateQualifiedUsersGroupTest.php
+++ b/test/functional/WorkerUpdateQualifiedUsersGroupTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use UnityWebPortal\lib\UserFlag;
+
+class WorkerUpdateQualifiedUsersGroupTest extends UnityWebPortalTestCase
+{
+    public function testQualifyUser()
+    {
+        global $USER, $LDAP, $SQL, $MAILER, $WEBHOOK;
+        $this->switchUser("EmptyPIGroupOwner");
+        $pi_group = $USER->getPIGroup();
+        $this->switchUser("Blank");
+        $user = $USER;
+        $expectedOutput = ["added" => [$user->uid], "removed" => []];
+        try {
+            $pi_group_entry = $LDAP->getPIGroupEntry($pi_group->gid);
+            $pi_group_entry->appendAttribute("memberuid", $user->uid);
+            [$_, $output_lines] = executeWorker("update-qualified-users-group.php");
+            $output_str = implode("\n", $output_lines);
+            $output = jsonDecode($output_str, associative: true);
+            $this->assertEquals($expectedOutput, $output);
+        } finally {
+            if ($pi_group->memberUIDExists($user->uid)) {
+                $pi_group->removeUser($user);
+            }
+            $this->assertFalse($user->getFlag(UserFlag::QUALIFIED));
+        }
+    }
+
+    public function testDisqualifyUser()
+    {
+        global $USER, $LDAP, $SQL, $MAILER, $WEBHOOK;
+        $this->switchUser("Blank");
+        $expectedOutput = ["added" => [], "removed" => [$USER->uid]];
+        try {
+            $qualified_user_group = $LDAP->userFlagGroups["qualified"];
+            $qualified_user_group->addMemberUID($USER->uid);
+            [$_, $output_lines] = executeWorker("update-qualified-users-group.php");
+            $output_str = implode("\n", $output_lines);
+            $output = jsonDecode($output_str, associative: true);
+            $this->assertEquals($expectedOutput, $output);
+        } finally {
+            if ($USER->getFlag(UserFlag::QUALIFIED)) {
+                $USER->setFlag(UserFlag::QUALIFIED, false);
+            }
+        }
+    }
+}

--- a/test/phpunit-bootstrap.php
+++ b/test/phpunit-bootstrap.php
@@ -197,6 +197,9 @@ function ensurePIGroupDoesNotExist()
         $LDAP->getPIGroupEntry($gid)->delete();
         ensure(!$USER->getPIGroup()->exists());
     }
+    if (count($USER->getPIGroupGIDs()) === 0) {
+        $USER->setFlag(UserFlag::QUALIFIED, false);
+    }
 }
 
 function callPrivateMethod($obj, $name, ...$args)
@@ -218,19 +221,30 @@ class UnityWebPortalTestCase extends TestCase
         "user3_org1_test" => ["user3@org1.test", "foo", "bar", "user3@org1.test"],
         "user4_org1_test" => ["user4@org1.test", "foo", "bar", "user4@org1.test"],
         "user5_org2_test" => ["user5@org2.test", "foo", "bar", "user5@org2.test"],
+        "user6_org1_test" => ["user6@org1.test", "foo", "bar", "user6@org1.test"],
+        "user7_org1_test" => ["user7@org1.test", "foo", "bar", "user7@org1.test"],
+        "user8_org1_test" => ["user8@org1.test", "foo", "bar", "user8@org1.test"],
+        "user9_org3_test" => ["user9@org3.test", "foo", "bar", "user9@org3.test"],
+        "user10_org1_test" => ["user10@org1.test", "foo", "bar", "user10@org1.test"],
         "user2001_org998_test" => ["user2001@org998.test", "foo", "bar", "user2001@org998.test"],
         "user2002_org998_test" => ["user2002@org998.test", "foo", "bar", "user2002@org998.test"],
         "user2003_org998_test" => ["user2003@org1.test", "foo", "bar", "user2001@org1.test"],
         "user2004_org998_test" => ["user2004@org1.test", "foo", "bar", "user2001@org1.test"],
         "user2005_org1_test" => ["user2005@org1.test", "foo", "bar", "user2005@org1.test"],
     ];
-    private static array $NICKNAME2UID = [
+    public static array $NICKNAME2UID = [
         "Admin" => "user1_org1_test",
         "Blank" => "user2_org1_test",
         "EmptyPIGroupOwner" => "user5_org2_test",
         "CustomMapped555" => "user2002_org998_test",
+        "Ghost" => "user7_org1_test",
+        "GhostNotPI" => "user7_org1_test",
+        "GhostOwnerOfDefunctPIGroup" => "user9_org3_test",
+        "ResurrectedOwnerOfDefunctPIGroup" => "user10_org1_test",
         "HasNoSshKeys" => "user3_org1_test",
         "HasOneSshKey" => "user5_org2_test",
+        "IdleLocked" => "user6_org1_test",
+        "Locked" => "user8_org1_test",
         "NonExistent" => "user2001_org998_test",
         "Normal" => "user4_org1_test",
         "NormalPI" => "user1_org1_test",
@@ -239,6 +253,9 @@ class UnityWebPortalTestCase extends TestCase
     private function validateUser(string $nickname)
     {
         global $USER, $SQL, $LDAP;
+        if (!array_key_exists($nickname, self::$NICKNAME2UID)) {
+            throw new ArrayKeyException($nickname);
+        }
         $this->assertEquals(self::$NICKNAME2UID[$nickname], $USER->uid);
         switch ($nickname) {
             case "Admin":
@@ -272,8 +289,35 @@ class UnityWebPortalTestCase extends TestCase
                 $this->assertEqualsCanonicalizing([$USER->uid], $pi_group->getMemberUIDs());
                 $this->assertEqualsCanonicalizing([], $pi_group->getRequests());
                 break;
+            case "Ghost":
+                $this->assertTrue($USER->getFlag(UserFlag::GHOST));
+                break;
+            case "GhostOwnerOfDefunctPIGroup":
+                $this->assertTrue($USER->getFlag(UserFlag::GHOST));
+                $this->assertTrue($USER->getPIGroup()->exists());
+                $this->assertTrue($USER->getPIGroup()->getIsDefunct());
+                break;
+            case "GhostNotPI":
+                $this->assertTrue($USER->getFlag(UserFlag::GHOST));
+                $this->assertFalse($USER->getPIGroup()->exists());
+                break;
+            case "ResurrectedOwnerOfDefunctPIGroup":
+                $this->assertTrue($USER->exists());
+                $this->assertFalse($USER->getFlag(UserFlag::GHOST));
+                $this->assertFalse($USER->isPI());
+                $this->assertTrue($USER->getPIGroup()->exists());
+                $this->assertTrue($USER->getPIGroup()->getIsDefunct());
+                break;
             case "HasNoSshKeys":
                 $this->assertEqualsCanonicalizing([], $USER->getSSHKeys());
+                break;
+            case "IdleLocked":
+                // this cannot be validated automatically because the user is already idle
+                // unlocked before this code runs
+                // $this->assertTrue($USER->getFlag(UserFlag::IDLELOCKED));
+                break;
+            case "Locked":
+                $this->assertTrue($USER->getFlag(UserFlag::LOCKED));
                 break;
             case "NonExistent":
                 $this->assertFalse($USER->exists());
@@ -461,10 +505,10 @@ class UnityWebPortalTestCase extends TestCase
         $_SERVER["givenName"] = $given_name;
         $_SERVER["sn"] = $sn;
         include __DIR__ . "/../resources/autoload.php";
-        ensure(!is_null($USER));
         if ($validate) {
             $this->validateUser($nickname);
         }
+        ensure(!is_null($USER));
     }
 
     function switchBackUser(bool $validate = false)

--- a/tools/docker-dev/identity/Dockerfile
+++ b/tools/docker-dev/identity/Dockerfile
@@ -12,6 +12,7 @@ RUN rm -rf /var/lib/ldap
 RUN mkdir /var/lib/ldap
 RUN chown openldap:openldap /var/lib/ldap
 COPY ssh.ldif /etc/ldap/schema/ssh.ldif
+COPY unity-cluster-schema.ldif /etc/ldap/schema/unity-cluster.ldif
 COPY ldap-config.ldif /tmp/ldap-config.ldif
 COPY bootstrap.ldif /tmp/bootstrap.ldif
 COPY load-modules.ldif /tmp/load-modules.ldif
@@ -22,6 +23,7 @@ RUN service slapd start; \
     ldapadd    -Y EXTERNAL -H ldapi:/// -f /etc/ldap/schema/nis.ldif; \
     ldapadd    -Y EXTERNAL -H ldapi:/// -f /etc/ldap/schema/inetorgperson.ldif; \
     ldapadd    -Y EXTERNAL -H ldapi:/// -f /etc/ldap/schema/ssh.ldif; \
+    ldapadd    -Y EXTERNAL -H ldapi:/// -f /etc/ldap/schema/unity-cluster.ldif; \
     ldapmodify -Y EXTERNAL -H ldapi:/// -f /tmp/ldap-config.ldif; \
     ldapmodify -Y EXTERNAL -H ldapi:/// -f /tmp/load-modules.ldif; \
     ldapadd    -Y EXTERNAL -H ldapi:/// -f /tmp/configure-unique.ldif; \

--- a/tools/docker-dev/identity/bootstrap.ldif
+++ b/tools/docker-dev/identity/bootstrap.ldif
@@ -45,18 +45,22 @@ cn: locked
 gidnumber: 502
 objectclass: posixGroup
 objectclass: top
+memberuid: user8_org1_test
 
 dn: cn=idlelocked,dc=unityhpc,dc=test
 cn: idlelocked
 gidnumber: 503
 objectclass: posixGroup
 objectclass: top
+memberuid: user6_org1_test
 
 dn: cn=ghost,dc=unityhpc,dc=test
 cn: ghost
 gidnumber: 504
 objectclass: posixGroup
 objectclass: top
+memberuid: user7_org1_test
+memberuid: user9_org3_test
 
 dn: cn=unityusers,dc=unityhpc,dc=test
 cn: unityusers
@@ -68,9 +72,7 @@ memberuid: user3_org1_test
 memberuid: user4_org1_test
 memberuid: user5_org2_test
 memberuid: user6_org1_test
-memberuid: user7_org1_test
 memberuid: user8_org1_test
-memberuid: user9_org3_test
 memberuid: user10_org1_test
 memberuid: user11_org1_test
 memberuid: user12_org1_test
@@ -78,7 +80,6 @@ memberuid: user13_org1_test
 memberuid: user14_org3_test
 memberuid: user15_org3_test
 memberuid: user16_org1_test
-memberuid: user17_org1_test
 memberuid: user18_org1_test
 memberuid: user19_org1_test
 memberuid: user20_org3_test
@@ -89,13 +90,10 @@ memberuid: user24_org2_test
 memberuid: user25_org1_test
 memberuid: user26_org1_test
 memberuid: user27_org1_test
-memberuid: user28_org1_test
 memberuid: user29_org1_test
 memberuid: user30_org1_test
 memberuid: user31_org1_test
 memberuid: user32_org1_test
-memberuid: user33_org3_test
-memberuid: user34_org1_test
 memberuid: user35_org1_test
 memberuid: user36_org2_test
 memberuid: user37_org1_test
@@ -111,7 +109,6 @@ memberuid: user46_org1_test
 memberuid: user47_org1_test
 memberuid: user48_org1_test
 memberuid: user49_org1_test
-memberuid: user50_org1_test
 memberuid: user51_org3_test
 memberuid: user52_org1_test
 memberuid: user53_org1_test
@@ -129,7 +126,6 @@ memberuid: user64_org1_test
 memberuid: user65_org1_test
 memberuid: user66_org2_test
 memberuid: user67_org2_test
-memberuid: user68_org1_test
 memberuid: user69_org2_test
 memberuid: user70_org1_test
 memberuid: user71_org1_test
@@ -145,7 +141,6 @@ memberuid: user80_org1_test
 memberuid: user81_org1_test
 memberuid: user82_org1_test
 memberuid: user83_org1_test
-memberuid: user84_org1_test
 memberuid: user85_org1_test
 memberuid: user86_org1_test
 memberuid: user87_org1_test
@@ -168,7 +163,6 @@ memberuid: user103_org1_test
 memberuid: user104_org2_test
 memberuid: user105_org3_test
 memberuid: user106_org1_test
-memberuid: user107_org1_test
 memberuid: user108_org1_test
 memberuid: user109_org1_test
 memberuid: user110_org1_test
@@ -181,10 +175,8 @@ memberuid: user116_org1_test
 memberuid: user117_org1_test
 memberuid: user118_org1_test
 memberuid: user119_org1_test
-memberuid: user120_org1_test
 memberuid: user121_org1_test
 memberuid: user122_org2_test
-memberuid: user123_org1_test
 memberuid: user124_org1_test
 memberuid: user125_org1_test
 memberuid: user126_org2_test
@@ -193,16 +185,12 @@ memberuid: user128_org1_test
 memberuid: user129_org2_test
 memberuid: user130_org1_test
 memberuid: user131_org1_test
-memberuid: user132_org1_test
-memberuid: user133_org1_test
 memberuid: user134_org1_test
 memberuid: user135_org1_test
-memberuid: user136_org1_test
 memberuid: user137_org1_test
 memberuid: user138_org3_test
 memberuid: user139_org1_test
 memberuid: user140_org2_test
-memberuid: user141_org1_test
 memberuid: user142_org1_test
 memberuid: user143_org1_test
 memberuid: user144_org1_test
@@ -221,11 +209,9 @@ memberuid: user156_org6_test
 memberuid: user157_org1_test
 memberuid: user158_org1_test
 memberuid: user159_org3_test
-memberuid: user160_org1_test
 memberuid: user161_org1_test
 memberuid: user162_org1_test
 memberuid: user163_org1_test
-memberuid: user164_org1_test
 memberuid: user165_org1_test
 memberuid: user166_org2_test
 memberuid: user167_org1_test
@@ -235,18 +221,14 @@ memberuid: user170_org2_test
 memberuid: user171_org1_test
 memberuid: user172_org1_test
 memberuid: user173_org1_test
-memberuid: user174_org1_test
 memberuid: user175_org1_test
 memberuid: user176_org2_test
-memberuid: user177_org1_test
 memberuid: user178_org1_test
 memberuid: user179_org1_test
-memberuid: user180_org1_test
 memberuid: user181_org1_test
 memberuid: user182_org1_test
 memberuid: user183_org2_test
 memberuid: user184_org1_test
-memberuid: user185_org1_test
 memberuid: user186_org1_test
 memberuid: user187_org1_test
 memberuid: user188_org1_test
@@ -254,7 +236,6 @@ memberuid: user189_org2_test
 memberuid: user190_org000000007_test
 memberuid: user191_org2_test
 memberuid: user192_org1_test
-memberuid: user193_org1_test
 memberuid: user194_org1_test
 memberuid: user195_org1_test
 memberuid: user196_org1_test
@@ -274,7 +255,6 @@ memberuid: user209_org1_test
 memberuid: user210_org2_test
 memberuid: user211_org000000007_test
 memberuid: user212_org1_test
-memberuid: user213_org1_test
 memberuid: user214_org1_test
 memberuid: user215_org1_test
 memberuid: user216_org1_test
@@ -284,13 +264,11 @@ memberuid: user219_org1_test
 memberuid: user220_org1_test
 memberuid: user221_org1_test
 memberuid: user222_org6_test
-memberuid: user223_org1_test
 memberuid: user224_org1_test
 memberuid: user225_org1_test
 memberuid: user226_org3_test
 memberuid: user227_org8_test
 memberuid: user228_org1_test
-memberuid: user229_org1_test
 memberuid: user230_org1_test
 memberuid: user231_org3_test
 memberuid: user232_org1_test
@@ -304,14 +282,12 @@ memberuid: user239_org1_test
 memberuid: user240_org1_test
 memberuid: user241_org1_test
 memberuid: user242_org1_test
-memberuid: user243_org1_test
 memberuid: user244_org1_test
 memberuid: user245_org1_test
 memberuid: user246_org1_test
 memberuid: user247_org1_test
 memberuid: user248_org2_test
 memberuid: user249_org3_test
-memberuid: user250_org1_test
 memberuid: user251_org2_test
 memberuid: user252_org1_test
 memberuid: user253_org1_test
@@ -323,7 +299,6 @@ memberuid: user258_org1_test
 memberuid: user259_org2_test
 memberuid: user260_org1_test
 memberuid: user261_org3_test
-memberuid: user262_org1_test
 memberuid: user263_org1_test
 memberuid: user264_org1_test
 memberuid: user265_org1_test
@@ -331,8 +306,6 @@ memberuid: user266_org1_test
 memberuid: user267_org1_test
 memberuid: user268_org1_test
 memberuid: user269_org1_test
-memberuid: user270_org10_test
-memberuid: user271_org1_test
 memberuid: user272_org1_test
 memberuid: user273_org1_test
 memberuid: user274_org2_test
@@ -340,30 +313,22 @@ memberuid: user275_org1_test
 memberuid: user276_org1_test
 memberuid: user277_org1_test
 memberuid: user278_org3_test
-memberuid: user279_org1_test
 memberuid: user280_org1_test
 memberuid: user281_org1_test
-memberuid: user282_org1_test
-memberuid: user283_org1_test
 memberuid: user284_org1_test
 memberuid: user285_org1_test
 memberuid: user286_org1_test
 memberuid: user287_org1_test
 memberuid: user288_org000000007_test
 memberuid: user289_org2_test
-memberuid: user290_org1_test
 memberuid: user291_org1_test
 memberuid: user292_org2_test
 memberuid: user293_org1_test
-memberuid: user294_org11_test
 memberuid: user295_org3_test
-memberuid: user296_org1_test
-memberuid: user297_org1_test
 memberuid: user298_org2_test
 memberuid: user299_org3_test
 memberuid: user300_org1_test
 memberuid: user301_org1_test
-memberuid: user302_org1_test
 memberuid: user303_org1_test
 memberuid: user304_org1_test
 memberuid: user305_org2_test
@@ -385,11 +350,8 @@ memberuid: user320_org1_test
 memberuid: user321_org2_test
 memberuid: user322_org2_test
 memberuid: user323_org1_test
-memberuid: user324_org1_test
 memberuid: user325_org1_test
 memberuid: user326_org3_test
-memberuid: user327_org1_test
-memberuid: user328_org1_test
 memberuid: user329_org1_test
 memberuid: user330_org1_test
 memberuid: user331_org1_test
@@ -412,14 +374,12 @@ memberuid: user347_org2_test
 memberuid: user348_org1_test
 memberuid: user349_org1_test
 memberuid: user350_org1_test
-memberuid: user351_org1_test
 memberuid: user352_org1_test
 memberuid: user353_org1_test
 memberuid: user354_org1_test
 memberuid: user355_org1_test
 memberuid: user356_org1_test
 memberuid: user357_org1_test
-memberuid: user358_org11_test
 memberuid: user359_org1_test
 memberuid: user360_org1_test
 memberuid: user361_org1_test
@@ -427,17 +387,12 @@ memberuid: user362_org1_test
 memberuid: user363_org1_test
 memberuid: user364_org1_test
 memberuid: user365_org1_test
-memberuid: user366_org1_test
-memberuid: user367_org1_test
-memberuid: user368_org1_test
 memberuid: user369_org1_test
-memberuid: user370_org3_test
 memberuid: user371_org1_test
 memberuid: user372_org1_test
 memberuid: user373_org1_test
 memberuid: user374_org1_test
 memberuid: user375_org2_test
-memberuid: user376_org1_test
 memberuid: user377_org1_test
 memberuid: user378_org1_test
 memberuid: user379_org1_test
@@ -448,8 +403,6 @@ memberuid: user383_org2_test
 memberuid: user384_org1_test
 memberuid: user385_org1_test
 memberuid: user386_org1_test
-memberuid: user387_org2_test
-memberuid: user388_org1_test
 memberuid: user389_org1_test
 memberuid: user390_org1_test
 memberuid: user391_org1_test
@@ -466,13 +419,11 @@ memberuid: user401_org1_test
 memberuid: user402_org1_test
 memberuid: user403_org2_test
 memberuid: user404_org3_test
-memberuid: user405_org1_test
 memberuid: user406_org3_test
 memberuid: user407_org1_test
 memberuid: user408_org2_test
 memberuid: user409_org1_test
 memberuid: user410_org2_test
-memberuid: user411_org1_test
 memberuid: user412_org2_test
 memberuid: user413_org1_test
 memberuid: user414_org1_test
@@ -480,14 +431,12 @@ memberuid: user415_org3_test
 memberuid: user416_org1_test
 memberuid: user417_org3_test
 memberuid: user418_org1_test
-memberuid: user419_org1_test
 memberuid: user420_org1_test
 memberuid: user421_org1_test
 memberuid: user422_org1_test
 memberuid: user423_org1_test
 memberuid: user424_org2_test
 memberuid: user424_org3_test
-memberuid: user425_org1_test
 memberuid: user426_org3_test
 memberuid: user427_org1_test
 memberuid: user428_org1_test
@@ -506,27 +455,22 @@ memberuid: user440_org1_test
 memberuid: user441_org1_test
 memberuid: user442_org1_test
 memberuid: user443_org1_test
-memberuid: user444_org1_test
 memberuid: user445_org1_test
 memberuid: user446_org1_test
 memberuid: user447_org1_test
 memberuid: user448_org1_test
 memberuid: user449_org1_test
-memberuid: user450_org1_test
 memberuid: user451_org1_test
 memberuid: user452_org1_test
 memberuid: user453_org1_test
 memberuid: user454_org1_test
 memberuid: user455_org1_test
-memberuid: user456_org1_test
 memberuid: user457_org1_test
 memberuid: user458_org1_test
 memberuid: user459_org1_test
 memberuid: user460_org1_test
-memberuid: user461_org1_test
 memberuid: user462_org1_test
 memberuid: user463_org1_test
-memberuid: user464_org1_test
 memberuid: user465_org1_test
 memberuid: user466_org2_test
 memberuid: user467_org2_test
@@ -537,8 +481,6 @@ memberuid: user471_org1_test
 memberuid: user472_org1_test
 memberuid: user473_org1_test
 memberuid: user474_org1_test
-memberuid: user475_org1_test
-memberuid: user476_org1_test
 memberuid: user477_org1_test
 memberuid: user478_org1_test
 memberuid: user479_org2_test
@@ -548,20 +490,14 @@ memberuid: user482_org1_test
 memberuid: user483_org1_test
 memberuid: user484_org1_test
 memberuid: user485_org1_test
-memberuid: user486_org1_test
 memberuid: user487_org2_test
-memberuid: user488_org1_test
-memberuid: user489_org1_test
 memberuid: user490_org1_test
 memberuid: user491_org4_test
 memberuid: user492_org1_test
-memberuid: user493_org1_test
 memberuid: user494_org8_test
 memberuid: user495_org1_test
 memberuid: user496_org1_test
 memberuid: user497_org1_test
-memberuid: user498_org1_test
-memberuid: user499_org11_test
 memberuid: user500_org1_test
 memberuid: user501_org1_test
 memberuid: user502_org1_test
@@ -576,11 +512,8 @@ memberuid: user510_org1_test
 memberuid: user511_org1_test
 memberuid: user512_org3_test
 memberuid: user513_org1_test
-memberuid: user514_org1_test
-memberuid: user515_org1_test
 memberuid: user516_org1_test
 memberuid: user517_org1_test
-memberuid: user518_org1_test
 memberuid: user519_org000000007_test
 memberuid: user520_org2_test
 memberuid: user521_org2_test
@@ -593,12 +526,10 @@ memberuid: user527_org1_test
 memberuid: user528_org1_test
 memberuid: user529_org1_test
 memberuid: user530_org1_test
-memberuid: user531_org1_test
 memberuid: user532_org000000007_test
 memberuid: user533_org1_test
 memberuid: user534_org1_test
 memberuid: user535_org1_test
-memberuid: user536_org1_test
 memberuid: user537_org2_test
 memberuid: user538_org2_test
 memberuid: user539_org1_test
@@ -620,7 +551,6 @@ memberuid: user554_org2_test
 memberuid: user555_org1_test
 memberuid: user556_org1_test
 memberuid: user557_org1_test
-memberuid: user558_org1_test
 memberuid: user559_org1_test
 memberuid: user560_org1_test
 memberuid: user561_org1_test
@@ -634,20 +564,15 @@ memberuid: user568_org1_test
 memberuid: user569_org1_test
 memberuid: user570_org1_test
 memberuid: user571_org1_test
-memberuid: user572_org1_test
 memberuid: user573_org1_test
 memberuid: user574_org1_test
 memberuid: user575_org1_test
 memberuid: user576_org1_test
-memberuid: user577_org1_test
-memberuid: user578_org1_test
-memberuid: user579_org1_test
 memberuid: user580_org1_test
 memberuid: user581_org1_test
 memberuid: user582_org1_test
 memberuid: user583_org1_test
 memberuid: user584_org2_test
-memberuid: user585_org1_test
 memberuid: user586_org1_test
 memberuid: user587_org1_test
 memberuid: user588_org1_test
@@ -666,7 +591,6 @@ memberuid: user600_org1_test
 memberuid: user601_org1_test
 memberuid: user602_org1_test
 memberuid: user603_org1_test
-memberuid: user604_org1_test
 memberuid: user605_org1_test
 memberuid: user606_org1_test
 memberuid: user607_org1_test
@@ -696,13 +620,10 @@ memberuid: user630_org3_test
 memberuid: user631_org1_test
 memberuid: user632_org1_test
 memberuid: user633_org1_test
-memberuid: user634_org1_test
 memberuid: user635_org1_test
 memberuid: user636_org2_test
 memberuid: user637_org1_test
-memberuid: user638_org10_test
 memberuid: user639_org3_test
-memberuid: user640_org1_test
 memberuid: user641_org1_test
 memberuid: user642_org1_test
 memberuid: user643_org1_test
@@ -717,7 +638,6 @@ memberuid: user651_org1_test
 memberuid: user652_org1_test
 memberuid: user653_org1_test
 memberuid: user654_org1_test
-memberuid: user655_org1_test
 memberuid: user656_org1_test
 memberuid: user657_org2_test
 memberuid: user658_org1_test
@@ -729,15 +649,12 @@ memberuid: user663_org2_test
 memberuid: user664_org1_test
 memberuid: user665_org1_test
 memberuid: user666_org1_test
-memberuid: user667_org1_test
-memberuid: user668_org1_test
 memberuid: user669_org2_test
 memberuid: user670_org1_test
 memberuid: user671_org1_test
 memberuid: user672_org3_test
 memberuid: user673_org3_test
 memberuid: user674_org1_test
-memberuid: user675_org1_test
 memberuid: user676_org1_test
 memberuid: user677_org1_test
 memberuid: user678_org1_test
@@ -746,14 +663,12 @@ memberuid: user680_org1_test
 memberuid: user681_org1_test
 memberuid: user682_org1_test
 memberuid: user683_org1_test
-memberuid: user684_org1_test
 memberuid: user685_org1_test
 memberuid: user686_org12_test
 memberuid: user687_org1_test
 memberuid: user688_org1_test
 memberuid: user689_org1_test
 memberuid: user690_org1_test
-memberuid: user691_org1_test
 memberuid: user692_org1_test
 memberuid: user693_org1_test
 memberuid: user694_org2_test
@@ -764,26 +679,19 @@ memberuid: user698_org1_test
 memberuid: user699_org1_test
 memberuid: user700_org1_test
 memberuid: user701_org1_test
-memberuid: user702_org1_test
 memberuid: user703_org11_test
 memberuid: user704_org1_test
 memberuid: user705_org2_test
-memberuid: user706_org1_test
-memberuid: user707_org1_test
 memberuid: user708_org1_test
 memberuid: user709_org2_test
 memberuid: user710_org11_test
-memberuid: user711_org1_test
 memberuid: user712_org1_test
-memberuid: user713_org1_test
 memberuid: user714_org2_test
 memberuid: user715_org1_test
 memberuid: user716_org2_test
 memberuid: user717_org2_test
-memberuid: user718_org1_test
 memberuid: user719_org1_test
 memberuid: user720_org1_test
-memberuid: user721_org1_test
 memberuid: user722_org1_test
 memberuid: user723_org2_test
 memberuid: user724_org1_test
@@ -832,11 +740,8 @@ memberuid: user766_org3_test
 memberuid: user767_org1_test
 memberuid: user768_org1_test
 memberuid: user769_org1_test
-memberuid: user770_org1_test
-memberuid: user771_org1_test
 memberuid: user772_org1_test
 memberuid: user773_org1_test
-memberuid: user774_org1_test
 memberuid: user775_org1_test
 memberuid: user776_org1_test
 memberuid: user777_org3_test
@@ -854,7 +759,6 @@ memberuid: user788_org2_test
 memberuid: user789_org3_test
 memberuid: user790_org1_test
 memberuid: user791_org2_test
-memberuid: user792_org1_test
 memberuid: user793_org1_test
 memberuid: user794_org1_test
 memberuid: user795_org1_test
@@ -870,27 +774,21 @@ memberuid: user804_org12_test
 memberuid: user805_org3_test
 memberuid: user806_org1_test
 memberuid: user807_org1_test
-memberuid: user808_org1_test
 memberuid: user809_org2_test
-memberuid: user810_org1_test
 memberuid: user811_org1_test
 memberuid: user812_org3_test
 memberuid: user813_org1_test
-memberuid: user814_org1_test
 memberuid: user815_org1_test
-memberuid: user816_org11_test
 memberuid: user817_org1_test
 memberuid: user818_org1_test
 memberuid: user819_org1_test
 memberuid: user820_org1_test
 memberuid: user821_org1_test
-memberuid: user822_org1_test
 memberuid: user823_org1_test
 memberuid: user824_org1_test
 memberuid: user825_org1_test
 memberuid: user826_org1_test
 memberuid: user827_org1_test
-memberuid: user828_org1_test
 memberuid: user829_org1_test
 memberuid: user830_org11_test
 memberuid: user831_org1_test
@@ -902,8 +800,6 @@ memberuid: user836_org1_test
 memberuid: user837_org1_test
 memberuid: user838_org1_test
 memberuid: user839_org2_test
-memberuid: user840_org1_test
-memberuid: user841_org1_test
 memberuid: user842_org1_test
 memberuid: user843_org1_test
 memberuid: user844_org1_test
@@ -924,7 +820,6 @@ memberuid: user858_org1_test
 memberuid: user859_org1_test
 memberuid: user860_org1_test
 memberuid: user861_org1_test
-memberuid: user862_org1_test
 memberuid: user863_org1_test
 memberuid: user864_org1_test
 memberuid: user865_org000000007_test
@@ -949,9 +844,7 @@ memberuid: user883_org3_test
 memberuid: user884_org1_test
 memberuid: user885_org1_test
 memberuid: user886_org1_test
-memberuid: user887_org1_test
 memberuid: user888_org1_test
-memberuid: user889_org1_test
 memberuid: user890_org3_test
 memberuid: user891_org1_test
 memberuid: user892_org1_test
@@ -968,7 +861,6 @@ memberuid: user902_org1_test
 memberuid: user903_org1_test
 memberuid: user904_org2_test
 memberuid: user905_org1_test
-memberuid: user906_org1_test
 memberuid: user907_org1_test
 memberuid: user908_org1_test
 memberuid: user909_org1_test
@@ -983,16 +875,12 @@ memberuid: user917_org1_test
 memberuid: user918_org1_test
 memberuid: user919_org1_test
 memberuid: user920_org1_test
-memberuid: user921_org1_test
-memberuid: user922_org1_test
-memberuid: user923_org1_test
 memberuid: user924_org1_test
 memberuid: user925_org1_test
 memberuid: user926_org1_test
 memberuid: user927_org1_test
 memberuid: user928_org1_test
 memberuid: user929_org2_test
-memberuid: user930_org2_test
 memberuid: user931_org1_test
 memberuid: user932_org1_test
 memberuid: user933_org2_test
@@ -1036,36 +924,24 @@ memberuid: user970_org1_test
 memberuid: user971_org1_test
 memberuid: user972_org10_test
 memberuid: user973_org1_test
-memberuid: user974_org1_test
 memberuid: user975_org1_test
 memberuid: user976_org1_test
 memberuid: user977_org1_test
 memberuid: user978_org1_test
 memberuid: user979_org2_test
-memberuid: user980_org1_test
 memberuid: user981_org1_test
 memberuid: user982_org1_test
-memberuid: user983_org1_test
 memberuid: user984_org1_test
 memberuid: user985_org2_test
-memberuid: user986_org1_test
 memberuid: user987_org2_test
 memberuid: user988_org1_test
-memberuid: user989_org11_test
-memberuid: user990_org1_test
 memberuid: user991_org1_test
 memberuid: user992_org1_test
 memberuid: user993_org1_test
 memberuid: user994_org1_test
-memberuid: user995_org1_test
-memberuid: user996_org1_test
-memberuid: user997_org1_test
 memberuid: user998_org1_test
-memberuid: user999_org1_test
-memberuid: user1000_org1_test
 memberuid: user1001_org1_test
 memberuid: user1002_org3_test
-memberuid: user1003_org1_test
 memberuid: user1004_org1_test
 memberuid: user1005_org3_test
 memberuid: user1006_org1_test
@@ -1075,7 +951,6 @@ memberuid: user1009_org1_test
 memberuid: user1010_org1_test
 memberuid: user1011_org1_test
 memberuid: user1012_org1_test
-memberuid: user1013_org1_test
 memberuid: user1014_org1_test
 memberuid: user1015_org1_test
 memberuid: user1016_org1_test
@@ -1087,19 +962,15 @@ memberuid: user1021_org1_test
 memberuid: user1022_org3_test
 memberuid: user1023_org1_test
 memberuid: user1024_org1_test
-memberuid: user1025_org1_test
 memberuid: user1026_org1_test
-memberuid: user1027_org1_test
 memberuid: user1028_org1_test
 memberuid: user1029_org1_test
-memberuid: user1030_org1_test
 memberuid: user1031_org1_test
 memberuid: user1032_org13_test
 memberuid: user1033_org1_test
 memberuid: user1034_org1_test
 memberuid: user1035_org1_test
 memberuid: user1036_org1_test
-memberuid: user1037_org1_test
 memberuid: user1038_org1_test
 memberuid: user1039_org1_test
 memberuid: user1040_org1_test
@@ -1109,20 +980,15 @@ memberuid: user1043_org1_test
 memberuid: user1044_org1_test
 memberuid: user1045_org1_test
 memberuid: user1046_org1_test
-memberuid: user1047_org1_test
-memberuid: user1048_org1_test
-memberuid: user1049_org1_test
 memberuid: user1050_org2_test
 memberuid: user1051_org1_test
 memberuid: user1052_org1_test
 memberuid: user1053_org1_test
 memberuid: user1054_org3_test
-memberuid: user1055_org2_test
 memberuid: user1056_org2_test
 memberuid: user1057_org1_test
 memberuid: user1058_org1_test
 memberuid: user1059_org1_test
-memberuid: user1060_org1_test
 memberuid: user1061_org1_test
 memberuid: user1062_org1_test
 memberuid: user1063_org1_test
@@ -1149,7 +1015,6 @@ memberuid: user1083_org1_test
 memberuid: user1084_org1_test
 memberuid: user1085_org1_test
 memberuid: user1086_org1_test
-memberuid: user1087_org1_test
 memberuid: user1088_org1_test
 memberuid: user1089_org1_test
 memberuid: user1090_org1_test
@@ -1164,7 +1029,6 @@ memberuid: user1098_org1_test
 memberuid: user1099_org1_test
 memberuid: user1100_org1_test
 memberuid: user1101_org14_test
-memberuid: user1102_org2_test
 memberuid: user1103_org2_test
 memberuid: user1104_org1_test
 memberuid: user1105_org1_test
@@ -1176,7 +1040,6 @@ memberuid: user1110_org2_test
 memberuid: user1111_org1_test
 memberuid: user1112_org1_test
 memberuid: user1113_org2_test
-memberuid: user1114_org1_test
 memberuid: user1115_org1_test
 memberuid: user1116_org1_test
 memberuid: user1117_org1_test
@@ -1184,10 +1047,8 @@ memberuid: user1118_org1_test
 memberuid: user1119_org1_test
 memberuid: user1120_org1_test
 memberuid: user1121_org5_test
-memberuid: user1122_org1_test
 memberuid: user1123_org1_test
 memberuid: user1124_org1_test
-memberuid: user1125_org1_test
 memberuid: user1126_org12_test
 memberuid: user1127_org1_test
 memberuid: user1128_org1_test
@@ -1198,7 +1059,6 @@ memberuid: user1132_org1_test
 memberuid: user1133_org2_test
 memberuid: user1134_org1_test
 memberuid: user1135_org1_test
-memberuid: user1136_org1_test
 memberuid: user1137_org1_test
 memberuid: user1138_org3_test
 memberuid: user1139_org1_test
@@ -1214,13 +1074,11 @@ memberuid: user1148_org1_test
 memberuid: user1149_org1_test
 memberuid: user1150_org1_test
 memberuid: user1151_org1_test
-memberuid: user1152_org1_test
 memberuid: user1153_org1_test
 memberuid: user1154_org1_test
 memberuid: user1155_org1_test
 memberuid: user1156_org1_test
 memberuid: user1157_org1_test
-memberuid: user1158_org13_test
 memberuid: user1159_org1_test
 memberuid: user1160_org1_test
 memberuid: user1161_org1_test
@@ -1230,7 +1088,6 @@ memberuid: user1164_org000000007_test
 memberuid: user1165_org1_test
 memberuid: user1166_org1_test
 memberuid: user1167_org1_test
-memberuid: user1168_org1_test
 memberuid: user1169_org1_test
 memberuid: user1170_org1_test
 memberuid: user1171_org1_test
@@ -1243,12 +1100,10 @@ memberuid: user1177_org1_test
 memberuid: user1178_org1_test
 memberuid: user1179_org1_test
 memberuid: user1180_org1_test
-memberuid: user1181_org1_test
 memberuid: user1182_org2_test
 memberuid: user1183_org1_test
 memberuid: user1184_org1_test
 memberuid: user1185_org1_test
-memberuid: user1186_org1_test
 memberuid: user1187_org1_test
 memberuid: user1188_org1_test
 memberuid: user1189_org2_test
@@ -1260,21 +1115,16 @@ memberuid: user1194_org1_test
 memberuid: user1195_org1_test
 memberuid: user1196_org1_test
 memberuid: user1197_org1_test
-memberuid: user1198_org1_test
 memberuid: user1199_org1_test
 memberuid: user1200_org1_test
 memberuid: user1201_org1_test
 memberuid: user1202_org1_test
 memberuid: user1203_org1_test
-memberuid: user1204_org1_test
 memberuid: user1205_org1_test
-memberuid: user1206_org2_test
-memberuid: user1207_org1_test
 memberuid: user1208_org1_test
 memberuid: user1209_org1_test
 memberuid: user1210_org1_test
 memberuid: user1211_org1_test
-memberuid: user1212_org1_test
 memberuid: user1213_org1_test
 memberuid: user1214_org1_test
 memberuid: user1215_org2_test
@@ -1283,16 +1133,12 @@ memberuid: user1217_org1_test
 memberuid: user1218_org1_test
 memberuid: user1219_org1_test
 memberuid: user1220_org1_test
-memberuid: user1221_org1_test
 memberuid: user1222_org1_test
 memberuid: user1223_org3_test
 memberuid: user1224_org1_test
 memberuid: user1225_org1_test
-memberuid: user1226_org1_test
 memberuid: user1227_org1_test
 memberuid: user1228_org1_test
-memberuid: user1229_org1_test
-memberuid: user1230_org1_test
 memberuid: user1231_org1_test
 memberuid: user1232_org1_test
 memberuid: user1233_org1_test
@@ -1300,23 +1146,16 @@ memberuid: user1234_org1_test
 memberuid: user1235_org3_test
 memberuid: user1236_org1_test
 memberuid: user1237_org1_test
-memberuid: user1238_org1_test
 memberuid: user1239_org1_test
 memberuid: user1240_org1_test
-memberuid: user1241_org1_test
-memberuid: user1242_org1_test
 memberuid: user1243_org1_test
-memberuid: user1244_org1_test
-memberuid: user1245_org1_test
 memberuid: user1246_org2_test
 memberuid: user1247_org1_test
 memberuid: user1248_org1_test
-memberuid: user1249_org1_test
 memberuid: user1250_org1_test
 memberuid: user1251_org1_test
 memberuid: user1252_org1_test
 memberuid: user1253_org1_test
-memberuid: user1254_org1_test
 memberuid: user1255_org1_test
 memberuid: user1256_org1_test
 memberuid: user1257_org1_test
@@ -1328,7 +1167,6 @@ memberuid: user1262_org1_test
 memberuid: user1263_org1_test
 memberuid: user1264_org1_test
 memberuid: user1265_org1_test
-memberuid: user1266_org1_test
 memberuid: user1267_org1_test
 memberuid: user1268_org1_test
 memberuid: user1269_org1_test
@@ -1336,12 +1174,9 @@ memberuid: user1270_org1_test
 memberuid: user1271_org1_test
 memberuid: user1272_org2_test
 memberuid: user1273_org1_test
-memberuid: user1274_org1_test
 memberuid: user1275_org1_test
 memberuid: user1276_org1_test
 memberuid: user1277_org1_test
-memberuid: user1278_org1_test
-memberuid: user1279_org1_test
 memberuid: user1280_org1_test
 memberuid: user1281_org1_test
 memberuid: user1282_org1_test
@@ -1364,8 +1199,6 @@ memberuid: user1298_org1_test
 memberuid: user1299_org1_test
 memberuid: user1300_org1_test
 memberuid: user1301_org1_test
-memberuid: user1302_org2_test
-memberuid: user1303_org1_test
 memberuid: user1304_org1_test
 
 dn: cn=user15_org3_test,ou=groups,dc=unityhpc,dc=test
@@ -10599,6 +10432,7 @@ cn: pi_user36_org2_test
 gidnumber: 10206
 memberuid: user36_org2_test
 memberuid: user912_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10671,6 +10505,7 @@ memberuid: user1095_org1_test
 memberuid: user414_org1_test
 memberuid: user1020_org1_test
 memberuid: user1177_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10678,6 +10513,7 @@ dn: cn=pi_user45_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user45_org1_test
 gidnumber: 10243
 memberuid: user45_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10686,6 +10522,7 @@ cn: pi_user51_org3_test
 gidnumber: 10222
 memberuid: user51_org3_test
 memberuid: user934_org3_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10704,6 +10541,7 @@ memberuid: user477_org1_test
 memberuid: user1265_org1_test
 memberuid: user1021_org1_test
 memberuid: user348_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10712,6 +10550,7 @@ cn: pi_user57_org2_test
 gidnumber: 10132
 memberuid: user57_org2_test
 memberuid: user67_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10719,6 +10558,7 @@ dn: cn=pi_user66_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user66_org2_test
 gidnumber: 10199
 memberuid: user66_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10733,6 +10573,7 @@ memberuid: user1073_org1_test
 memberuid: user1257_org1_test
 memberuid: user85_org1_test
 memberuid: user41_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10741,6 +10582,7 @@ cn: pi_user72_org3_test
 gidnumber: 10223
 memberuid: user72_org3_test
 memberuid: user1223_org3_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10749,6 +10591,7 @@ cn: pi_user78_org1_test
 gidnumber: 10157
 memberuid: user78_org1_test
 memberuid: user526_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10756,6 +10599,7 @@ dn: cn=pi_user93_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user93_org1_test
 gidnumber: 10101
 memberuid: user93_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10771,6 +10615,7 @@ memberuid: user747_org1_test
 memberuid: user516_org1_test
 memberuid: user821_org1_test
 memberuid: user1196_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10779,6 +10624,7 @@ cn: pi_user113_org1_test
 gidnumber: 10099
 memberuid: user113_org1_test
 memberuid: user272_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10791,6 +10637,7 @@ memberuid: user791_org2_test
 memberuid: user987_org2_test
 memberuid: user904_org2_test
 memberuid: user839_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10803,6 +10650,7 @@ memberuid: user60_org1_test
 memberuid: user29_org1_test
 memberuid: user46_org1_test
 memberuid: user734_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10812,6 +10660,7 @@ gidnumber: 10063
 memberuid: user135_org1_test
 memberuid: user860_org1_test
 memberuid: user574_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10823,6 +10672,7 @@ memberuid: user512_org3_test
 memberuid: user406_org3_test
 memberuid: user1054_org3_test
 memberuid: user850_org3_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10831,6 +10681,7 @@ cn: pi_user149_org1_test
 gidnumber: 10071
 memberuid: user149_org1_test
 memberuid: user263_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10840,6 +10691,7 @@ gidnumber: 10254
 memberuid: user150_org1_test
 memberuid: user1250_org1_test
 memberuid: user208_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10847,6 +10699,7 @@ dn: cn=pi_user162_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user162_org1_test
 gidnumber: 10228
 memberuid: user162_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10856,6 +10709,7 @@ gidnumber: 10179
 memberuid: user163_org1_test
 memberuid: user300_org1_test
 memberuid: user749_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10863,6 +10717,7 @@ dn: cn=pi_user166_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user166_org2_test
 gidnumber: 10165
 memberuid: user166_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10872,6 +10727,7 @@ gidnumber: 10009
 memberuid: user167_org1_test
 memberuid: user1097_org1_test
 memberuid: user690_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10879,6 +10735,7 @@ dn: cn=pi_user176_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user176_org2_test
 gidnumber: 10216
 memberuid: user176_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10887,6 +10744,7 @@ cn: pi_user181_org1_test
 gidnumber: 10245
 memberuid: user181_org1_test
 memberuid: user909_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10896,6 +10754,7 @@ gidnumber: 10150
 memberuid: user182_org1_test
 memberuid: user752_org1_test
 memberuid: user529_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10907,6 +10766,7 @@ memberuid: user99_org1_test
 memberuid: user1141_org1_test
 memberuid: user236_org1_test
 memberuid: user757_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10914,6 +10774,7 @@ dn: cn=pi_user188_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user188_org1_test
 gidnumber: 10143
 memberuid: user188_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10923,6 +10784,7 @@ gidnumber: 10260
 memberuid: user190_org000000007_test
 memberuid: user211_org000000007_test
 memberuid: user1164_org000000007_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10931,6 +10793,7 @@ cn: pi_user191_org2_test
 gidnumber: 10181
 memberuid: user191_org2_test
 memberuid: user1113_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10949,6 +10812,7 @@ memberuid: user1032_org13_test
 memberuid: user851_org1_test
 memberuid: user576_org1_test
 memberuid: user508_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10956,6 +10820,7 @@ dn: cn=pi_user5_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user5_org2_test
 gidnumber: 10135
 memberuid: user5_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10965,6 +10830,7 @@ gidnumber: 10230
 memberuid: user197_org3_test
 memberuid: user639_org3_test
 memberuid: user748_org3_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10977,6 +10843,7 @@ memberuid: user269_org1_test
 memberuid: user1007_org1_test
 memberuid: user1258_org1_test
 memberuid: user317_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10985,6 +10852,7 @@ cn: pi_user200_org2_test
 gidnumber: 10275
 memberuid: user200_org2_test
 memberuid: user662_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10992,6 +10860,7 @@ dn: cn=pi_user201_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user201_org1_test
 gidnumber: 10010
 memberuid: user201_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10999,6 +10868,7 @@ dn: cn=pi_user205_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user205_org1_test
 gidnumber: 10274
 memberuid: user205_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11011,6 +10881,7 @@ memberuid: user588_org1_test
 memberuid: user384_org1_test
 memberuid: user1081_org1_test
 memberuid: user772_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11018,6 +10889,7 @@ dn: cn=pi_user207_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user207_org1_test
 gidnumber: 10220
 memberuid: user207_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11032,6 +10904,7 @@ memberuid: user566_org1_test
 memberuid: user511_org1_test
 memberuid: user950_org1_test
 memberuid: user894_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11039,6 +10912,7 @@ dn: cn=pi_user214_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user214_org1_test
 gidnumber: 10145
 memberuid: user214_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11054,6 +10928,7 @@ memberuid: user1016_org1_test
 memberuid: user776_org1_test
 memberuid: user1285_org1_test
 memberuid: user472_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11065,6 +10940,7 @@ memberuid: user645_org1_test
 memberuid: user745_org1_test
 memberuid: user230_org1_test
 memberuid: user364_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11072,21 +10948,31 @@ dn: cn=pi_user226_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user226_org3_test
 gidnumber: 10164
 memberuid: user226_org3_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
 dn: cn=pi_user9_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user9_org3_test
 gidnumber: 10094
-memberuid: user9_org3_test
-memberuid: user33_org3_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
+isDefunct: TRUE
+
+dn: cn=pi_user10_org1_test,ou=pi_groups,dc=unityhpc,dc=test
+cn: pi_user10_org1_test
+gidnumber: 2257
+objectclass: unityClusterPIGroup
+objectclass: posixGroup
+objectclass: top
+isDefunct: TRUE
 
 dn: cn=pi_user242_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user242_org1_test
 gidnumber: 10052
 memberuid: user242_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11095,6 +10981,7 @@ cn: pi_user247_org1_test
 gidnumber: 10126
 memberuid: user247_org1_test
 memberuid: user178_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11106,6 +10993,7 @@ memberuid: user482_org1_test
 memberuid: user254_org1_test
 memberuid: user1239_org1_test
 memberuid: user918_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11113,6 +11001,7 @@ dn: cn=pi_user253_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user253_org1_test
 gidnumber: 10013
 memberuid: user253_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11137,6 +11026,7 @@ memberuid: user767_org1_test
 memberuid: user56_org1_test
 memberuid: user1200_org1_test
 memberuid: user280_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11144,6 +11034,7 @@ dn: cn=pi_user264_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user264_org1_test
 gidnumber: 10073
 memberuid: user264_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11152,6 +11043,7 @@ cn: pi_user266_org1_test
 gidnumber: 10162
 memberuid: user266_org1_test
 memberuid: user111_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11159,6 +11051,7 @@ dn: cn=pi_user268_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user268_org1_test
 gidnumber: 10239
 memberuid: user268_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11166,6 +11059,7 @@ dn: cn=pi_user274_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user274_org2_test
 gidnumber: 10283
 memberuid: user274_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11177,6 +11071,7 @@ memberuid: user978_org1_test
 memberuid: user155_org1_test
 memberuid: user629_org1_test
 memberuid: user217_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11185,6 +11080,7 @@ cn: pi_user278_org3_test
 gidnumber: 10180
 memberuid: user278_org3_test
 memberuid: user20_org3_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11192,6 +11088,7 @@ dn: cn=pi_user288_org000000007_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user288_org000000007_test
 gidnumber: 10234
 memberuid: user288_org000000007_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11202,6 +11099,7 @@ memberuid: user291_org1_test
 memberuid: user473_org1_test
 memberuid: user110_org1_test
 memberuid: user441_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11209,6 +11107,7 @@ dn: cn=pi_user292_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user292_org2_test
 gidnumber: 10229
 memberuid: user292_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11216,6 +11115,7 @@ dn: cn=pi_user295_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user295_org3_test
 gidnumber: 10277
 memberuid: user295_org3_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11225,6 +11125,7 @@ gidnumber: 10209
 memberuid: user303_org1_test
 memberuid: user365_org1_test
 memberuid: user389_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11232,6 +11133,7 @@ dn: cn=pi_user304_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user304_org1_test
 gidnumber: 10248
 memberuid: user304_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11243,6 +11145,7 @@ memberuid: user58_org1_test
 memberuid: user824_org1_test
 memberuid: user21_org1_test
 memberuid: user447_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11253,6 +11156,7 @@ memberuid: user312_org1_test
 memberuid: user794_org1_test
 memberuid: user1031_org1_test
 memberuid: user556_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11262,6 +11166,7 @@ gidnumber: 10112
 memberuid: user315_org2_test
 memberuid: user392_org2_test
 memberuid: user866_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11270,6 +11175,7 @@ cn: pi_user326_org3_test
 gidnumber: 10173
 memberuid: user326_org3_test
 memberuid: user883_org3_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11279,6 +11185,7 @@ gidnumber: 10136
 memberuid: user329_org1_test
 memberuid: user46_org1_test
 memberuid: user148_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11286,6 +11193,7 @@ dn: cn=pi_user331_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user331_org1_test
 gidnumber: 10227
 memberuid: user331_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11294,6 +11202,7 @@ cn: pi_user336_org1_test
 gidnumber: 10137
 memberuid: user336_org1_test
 memberuid: user478_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11302,6 +11211,7 @@ cn: pi_user338_org1_test
 gidnumber: 10267
 memberuid: user338_org1_test
 memberuid: user1149_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11316,6 +11226,7 @@ memberuid: user570_org1_test
 memberuid: user888_org1_test
 memberuid: user343_org1_test
 memberuid: user535_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11324,6 +11235,7 @@ cn: pi_user345_org1_test
 gidnumber: 10186
 memberuid: user345_org1_test
 memberuid: user1084_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11331,6 +11243,7 @@ dn: cn=pi_user346_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user346_org2_test
 gidnumber: 10246
 memberuid: user346_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11339,6 +11252,7 @@ cn: pi_user347_org2_test
 gidnumber: 10081
 memberuid: user347_org2_test
 memberuid: user24_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11346,6 +11260,7 @@ dn: cn=pi_user354_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user354_org1_test
 gidnumber: 10016
 memberuid: user354_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11360,6 +11275,7 @@ memberuid: user908_org1_test
 memberuid: user434_org1_test
 memberuid: user1180_org1_test
 memberuid: user1024_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11367,6 +11283,7 @@ dn: cn=pi_user372_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user372_org1_test
 gidnumber: 10053
 memberuid: user372_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11380,6 +11297,7 @@ memberuid: user301_org1_test
 memberuid: user401_org1_test
 memberuid: user306_org1_test
 memberuid: user1286_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11388,6 +11306,7 @@ cn: pi_user382_org1_test
 gidnumber: 10219
 memberuid: user382_org1_test
 memberuid: user590_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11395,6 +11314,7 @@ dn: cn=pi_user386_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user386_org1_test
 gidnumber: 10197
 memberuid: user386_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11404,6 +11324,7 @@ gidnumber: 10098
 memberuid: user391_org1_test
 memberuid: user63_org1_test
 memberuid: user874_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11411,6 +11332,7 @@ dn: cn=pi_user393_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user393_org1_test
 gidnumber: 10017
 memberuid: user393_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11419,6 +11341,7 @@ cn: pi_user395_org1_test
 gidnumber: 10122
 memberuid: user395_org1_test
 memberuid: user993_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11427,6 +11350,7 @@ cn: pi_user398_org1_test
 gidnumber: 10169
 memberuid: user398_org1_test
 memberuid: user394_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11437,6 +11361,7 @@ memberuid: user400_org1_test
 memberuid: user712_org1_test
 memberuid: user91_org1_test
 memberuid: user653_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11445,6 +11370,7 @@ cn: pi_user404_org3_test
 gidnumber: 10152
 memberuid: user404_org3_test
 memberuid: user145_org3_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11452,6 +11378,7 @@ dn: cn=pi_user407_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user407_org1_test
 gidnumber: 10238
 memberuid: user407_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11462,6 +11389,7 @@ memberuid: user415_org3_test
 memberuid: user261_org3_test
 memberuid: user14_org3_test
 memberuid: user333_org3_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11470,6 +11398,7 @@ cn: pi_user416_org1_test
 gidnumber: 10279
 memberuid: user416_org1_test
 memberuid: user952_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11478,6 +11407,7 @@ cn: pi_user420_org1_test
 gidnumber: 10147
 memberuid: user420_org1_test
 memberuid: user977_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11486,6 +11416,7 @@ cn: pi_user423_org1_test
 gidnumber: 10252
 memberuid: user423_org1_test
 memberuid: user1211_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11493,6 +11424,7 @@ dn: cn=pi_user424_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user424_org3_test
 gidnumber: 10011
 memberuid: user424_org3_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11508,6 +11440,7 @@ memberuid: user972_org10_test
 memberuid: user251_org2_test
 memberuid: user170_org2_test
 memberuid: user1002_org3_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11518,6 +11451,7 @@ memberuid: user426_org3_test
 memberuid: user112_org3_test
 memberuid: user944_org3_test
 memberuid: user202_org3_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11526,6 +11460,7 @@ cn: pi_user432_org2_test
 gidnumber: 10212
 memberuid: user432_org2_test
 memberuid: user595_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11534,6 +11469,7 @@ cn: pi_user433_org1_test
 gidnumber: 10156
 memberuid: user433_org1_test
 memberuid: user209_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11541,6 +11477,7 @@ dn: cn=pi_user436_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user436_org2_test
 gidnumber: 10236
 memberuid: user436_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11556,6 +11493,7 @@ memberuid: user422_org1_test
 memberuid: user168_org1_test
 memberuid: user759_org1_test
 memberuid: user661_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11566,6 +11504,7 @@ memberuid: user439_org2_test
 memberuid: user412_org2_test
 memberuid: user780_org2_test
 memberuid: user1133_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11576,6 +11515,7 @@ memberuid: user440_org1_test
 memberuid: user89_org1_test
 memberuid: user1080_org1_test
 memberuid: user146_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11585,6 +11525,7 @@ gidnumber: 10263
 memberuid: user442_org1_test
 memberuid: user700_org1_test
 memberuid: user1053_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11606,6 +11547,7 @@ memberuid: user1155_org1_test
 memberuid: user1008_org1_test
 memberuid: user468_org1_test
 memberuid: user240_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11615,6 +11557,7 @@ gidnumber: 10003
 memberuid: user452_org1_test
 memberuid: user316_org1_test
 memberuid: user746_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11624,6 +11567,7 @@ gidnumber: 10118
 memberuid: user453_org1_test
 memberuid: user1210_org1_test
 memberuid: user555_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11639,6 +11583,7 @@ memberuid: user874_org1_test
 memberuid: user963_org1_test
 memberuid: user397_org1_test
 memberuid: user910_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11647,6 +11592,7 @@ cn: pi_user460_org1_test
 gidnumber: 10172
 memberuid: user460_org1_test
 memberuid: user172_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11654,6 +11600,7 @@ dn: cn=pi_user466_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user466_org2_test
 gidnumber: 10166
 memberuid: user466_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11663,6 +11610,7 @@ gidnumber: 10129
 memberuid: user467_org2_test
 memberuid: user723_org2_test
 memberuid: user259_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11671,6 +11619,7 @@ cn: pi_user480_org1_test
 gidnumber: 10168
 memberuid: user480_org1_test
 memberuid: user900_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11709,6 +11658,7 @@ memberuid: user899_org1_test
 memberuid: user924_org1_test
 memberuid: user1295_org1_test
 memberuid: user1061_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11725,6 +11675,7 @@ memberuid: user553_org2_test
 memberuid: user129_org2_test
 memberuid: user669_org2_test
 memberuid: user648_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11756,6 +11707,7 @@ memberuid: user982_org1_test
 memberuid: user75_org1_test
 memberuid: user151_org1_test
 memberuid: user557_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11779,6 +11731,7 @@ memberuid: user895_org1_test
 memberuid: user623_org1_test
 memberuid: user97_org1_test
 memberuid: user953_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11789,6 +11742,7 @@ memberuid: user502_org1_test
 memberuid: user1072_org1_test
 memberuid: user1194_org1_test
 memberuid: user82_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11802,7 +11756,7 @@ memberuid: user716_org2_test
 memberuid: user584_org2_test
 memberuid: user788_org2_test
 memberuid: user170_org2_test
-memberuid: user5_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11810,6 +11764,7 @@ dn: cn=pi_user513_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user513_org1_test
 gidnumber: 10108
 memberuid: user513_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11819,6 +11774,7 @@ gidnumber: 10251
 memberuid: user517_org1_test
 memberuid: user1253_org1_test
 memberuid: user616_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11826,6 +11782,7 @@ dn: cn=pi_user519_org000000007_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user519_org000000007_test
 gidnumber: 10259
 memberuid: user519_org000000007_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11834,6 +11791,7 @@ cn: pi_user528_org1_test
 gidnumber: 10104
 memberuid: user528_org1_test
 memberuid: user799_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11845,6 +11803,7 @@ memberuid: user1222_org1_test
 memberuid: user16_org1_test
 memberuid: user1131_org1_test
 memberuid: user402_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11852,6 +11811,7 @@ dn: cn=pi_user532_org000000007_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user532_org000000007_test
 gidnumber: 10174
 memberuid: user532_org000000007_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11864,6 +11824,7 @@ memberuid: user353_org1_test
 memberuid: user869_org1_test
 memberuid: user1116_org1_test
 memberuid: user896_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11925,6 +11886,7 @@ memberuid: user1218_org1_test
 memberuid: user1202_org1_test
 memberuid: user1217_org1_test
 memberuid: user960_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11938,13 +11900,13 @@ memberuid: user264_org1_test
 memberuid: user10_org1_test
 memberuid: user6_org1_test
 memberuid: user8_org1_test
-memberuid: user5_org2_test
 memberuid: user698_org1_test
 memberuid: user1065_org1_test
 memberuid: user491_org4_test
 memberuid: user689_org1_test
 memberuid: user12_org1_test
 memberuid: user697_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11953,6 +11915,7 @@ cn: pi_user546_org1_test
 gidnumber: 10193
 memberuid: user546_org1_test
 memberuid: user103_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11961,6 +11924,7 @@ cn: pi_user550_org1_test
 gidnumber: 10187
 memberuid: user550_org1_test
 memberuid: user1107_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11974,6 +11938,7 @@ memberuid: user385_org1_test
 memberuid: user1219_org1_test
 memberuid: user992_org1_test
 memberuid: user1023_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11981,6 +11946,7 @@ dn: cn=pi_user554_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user554_org2_test
 gidnumber: 10241
 memberuid: user554_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11989,6 +11955,7 @@ cn: pi_user559_org1_test
 gidnumber: 10004
 memberuid: user559_org1_test
 memberuid: user509_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11998,6 +11965,7 @@ gidnumber: 10057
 memberuid: user560_org1_test
 memberuid: user875_org1_test
 memberuid: user589_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12007,6 +11975,7 @@ gidnumber: 10054
 memberuid: user561_org1_test
 memberuid: user932_org1_test
 memberuid: user25_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12014,6 +11983,7 @@ dn: cn=pi_user564_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user564_org1_test
 gidnumber: 10123
 memberuid: user564_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12047,6 +12017,7 @@ memberuid: user544_org1_test
 memberuid: user61_org1_test
 memberuid: user846_org1_test
 memberuid: user1167_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12063,6 +12034,7 @@ memberuid: user611_org1_test
 memberuid: user1132_org1_test
 memberuid: user378_org1_test
 memberuid: user143_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12071,6 +12043,7 @@ cn: pi_user575_org1_test
 gidnumber: 10092
 memberuid: user575_org1_test
 memberuid: user863_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12078,6 +12051,7 @@ dn: cn=pi_user580_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user580_org1_test
 gidnumber: 10119
 memberuid: user580_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12085,6 +12059,7 @@ dn: cn=pi_user582_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user582_org1_test
 gidnumber: 10051
 memberuid: user582_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12092,6 +12067,7 @@ dn: cn=pi_user586_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user586_org1_test
 gidnumber: 10020
 memberuid: user586_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12103,6 +12079,7 @@ memberuid: user1104_org1_test
 memberuid: user357_org1_test
 memberuid: user39_org1_test
 memberuid: user281_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12111,6 +12088,7 @@ cn: pi_user592_org2_test
 gidnumber: 10235
 memberuid: user592_org2_test
 memberuid: user410_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12133,6 +12111,7 @@ memberuid: user234_org9_test
 memberuid: user258_org1_test
 memberuid: user728_org9_test
 memberuid: user1147_org9_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12140,6 +12119,7 @@ dn: cn=pi_user608_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user608_org1_test
 gidnumber: 10070
 memberuid: user608_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12152,6 +12132,7 @@ memberuid: user37_org1_test
 memberuid: user1216_org1_test
 memberuid: user583_org1_test
 memberuid: user838_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12159,6 +12140,7 @@ dn: cn=pi_user626_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user626_org1_test
 gidnumber: 10107
 memberuid: user626_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12166,6 +12148,7 @@ dn: cn=pi_user635_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user635_org1_test
 gidnumber: 10175
 memberuid: user635_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12174,6 +12157,7 @@ cn: pi_user636_org2_test
 gidnumber: 10195
 memberuid: user636_org2_test
 memberuid: user694_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12184,6 +12168,7 @@ memberuid: user641_org1_test
 memberuid: user239_org1_test
 memberuid: user1017_org1_test
 memberuid: user409_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12193,6 +12178,7 @@ gidnumber: 10115
 memberuid: user647_org1_test
 memberuid: user739_org1_test
 memberuid: user800_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12201,6 +12187,7 @@ cn: pi_user656_org1_test
 gidnumber: 10064
 memberuid: user656_org1_test
 memberuid: user80_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12209,6 +12196,7 @@ cn: pi_user659_org1_test
 gidnumber: 10144
 memberuid: user659_org1_test
 memberuid: user265_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12216,6 +12204,7 @@ dn: cn=pi_user663_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user663_org2_test
 gidnumber: 10202
 memberuid: user663_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12227,6 +12216,7 @@ memberuid: user495_org1_test
 memberuid: user319_org1_test
 memberuid: user678_org1_test
 memberuid: user379_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12235,6 +12225,7 @@ cn: pi_user670_org1_test
 gidnumber: 10062
 memberuid: user670_org1_test
 memberuid: user195_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12243,6 +12234,7 @@ cn: pi_user674_org1_test
 gidnumber: 10217
 memberuid: user674_org1_test
 memberuid: user680_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12255,6 +12247,7 @@ memberuid: user62_org1_test
 memberuid: user649_org1_test
 memberuid: user381_org1_test
 memberuid: user1085_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12265,6 +12258,7 @@ memberuid: user677_org1_test
 memberuid: user1294_org1_test
 memberuid: user1161_org1_test
 memberuid: user484_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12290,6 +12284,7 @@ memberuid: user533_org1_test
 memberuid: user524_org1_test
 memberuid: user596_org1_test
 memberuid: user267_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12305,6 +12300,7 @@ memberuid: user352_org1_test
 memberuid: user825_org1_test
 memberuid: user598_org1_test
 memberuid: user618_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12314,6 +12310,7 @@ gidnumber: 10211
 memberuid: user695_org2_test
 memberuid: user705_org2_test
 memberuid: user541_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12323,6 +12320,7 @@ gidnumber: 10075
 memberuid: user699_org1_test
 memberuid: user665_org1_test
 memberuid: user44_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12330,6 +12328,7 @@ dn: cn=pi_user703_org11_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user703_org11_test
 gidnumber: 10207
 memberuid: user703_org11_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12339,6 +12338,7 @@ gidnumber: 10044
 memberuid: user714_org2_test
 memberuid: user760_org2_test
 memberuid: user538_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12348,6 +12348,7 @@ gidnumber: 10200
 memberuid: user717_org2_test
 memberuid: user189_org2_test
 memberuid: user929_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12357,6 +12358,7 @@ gidnumber: 10161
 memberuid: user720_org1_test
 memberuid: user171_org1_test
 memberuid: user470_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12368,6 +12370,7 @@ memberuid: user276_org1_test
 memberuid: user497_org1_test
 memberuid: user811_org1_test
 memberuid: user88_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12376,6 +12379,7 @@ cn: pi_user724_org1_test
 gidnumber: 10045
 memberuid: user724_org1_test
 memberuid: user864_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12384,6 +12388,7 @@ cn: pi_user725_org2_test
 gidnumber: 10198
 memberuid: user725_org2_test
 memberuid: user876_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12392,6 +12397,7 @@ cn: pi_user727_org000000007_test
 gidnumber: 10266
 memberuid: user727_org000000007_test
 memberuid: user1192_org000000007_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12405,6 +12411,7 @@ memberuid: user38_org1_test
 memberuid: user377_org1_test
 memberuid: user224_org1_test
 memberuid: user451_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12416,6 +12423,7 @@ memberuid: user852_org1_test
 memberuid: user971_org1_test
 memberuid: user1139_org1_test
 memberuid: user951_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12469,6 +12477,7 @@ memberuid: user597_org1_test
 memberuid: user139_org1_test
 memberuid: user1026_org1_test
 memberuid: user109_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12476,6 +12485,7 @@ dn: cn=pi_user737_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user737_org1_test
 gidnumber: 10039
 memberuid: user737_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12485,6 +12495,7 @@ gidnumber: 10069
 memberuid: user743_org1_test
 memberuid: user1263_org1_test
 memberuid: user1098_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12494,6 +12505,7 @@ gidnumber: 10022
 memberuid: user744_org1_test
 memberuid: user704_org1_test
 memberuid: user787_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12512,6 +12524,7 @@ memberuid: user627_org1_test
 memberuid: user552_org1_test
 memberuid: user891_org1_test
 memberuid: user1034_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12519,6 +12532,7 @@ dn: cn=pi_user758_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user758_org1_test
 gidnumber: 10278
 memberuid: user758_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12526,6 +12540,7 @@ dn: cn=pi_user764_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user764_org1_test
 gidnumber: 10237
 memberuid: user764_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12547,6 +12562,7 @@ memberuid: user1248_org1_test
 memberuid: user854_org1_test
 memberuid: user984_org1_test
 memberuid: user1157_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12559,6 +12575,7 @@ memberuid: user729_org3_test
 memberuid: user15_org3_test
 memberuid: user417_org3_test
 memberuid: user766_org3_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12567,6 +12584,7 @@ cn: pi_user782_org1_test
 gidnumber: 10059
 memberuid: user782_org1_test
 memberuid: user1162_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12576,6 +12594,7 @@ gidnumber: 10167
 memberuid: user783_org1_test
 memberuid: user1057_org1_test
 memberuid: user991_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12584,6 +12603,7 @@ cn: pi_user784_org1_test
 gidnumber: 10281
 memberuid: user784_org1_test
 memberuid: user228_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12596,6 +12616,7 @@ memberuid: user1160_org1_test
 memberuid: user650_org1_test
 memberuid: user492_org1_test
 memberuid: user1256_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12606,6 +12627,7 @@ memberuid: user786_org1_test
 memberuid: user1146_org1_test
 memberuid: user301_org1_test
 memberuid: user942_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12613,6 +12635,7 @@ dn: cn=pi_user788_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user788_org2_test
 gidnumber: 10191
 memberuid: user788_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12626,6 +12649,7 @@ memberuid: user74_org3_test
 memberuid: user644_org3_test
 memberuid: user231_org3_test
 memberuid: user630_org3_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12633,6 +12657,7 @@ dn: cn=pi_user795_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user795_org1_test
 gidnumber: 10178
 memberuid: user795_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12641,6 +12666,7 @@ cn: pi_user796_org11_test
 gidnumber: 10133
 memberuid: user796_org11_test
 memberuid: user710_org11_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12649,6 +12675,7 @@ cn: pi_user798_org1_test
 gidnumber: 10035
 memberuid: user798_org1_test
 memberuid: user756_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12656,6 +12683,7 @@ dn: cn=pi_user801_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user801_org1_test
 gidnumber: 10271
 memberuid: user801_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12664,6 +12692,7 @@ cn: pi_user803_org1_test
 gidnumber: 10025
 memberuid: user803_org1_test
 memberuid: user1058_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12674,6 +12703,7 @@ memberuid: user805_org3_test
 memberuid: user154_org3_test
 memberuid: user672_org3_test
 memberuid: user673_org3_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12681,6 +12711,7 @@ dn: cn=pi_user809_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user809_org2_test
 gidnumber: 10190
 memberuid: user809_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12693,6 +12724,7 @@ memberuid: user998_org1_test
 memberuid: user581_org1_test
 memberuid: user1142_org1_test
 memberuid: user504_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12700,6 +12732,7 @@ dn: cn=pi_user830_org11_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user830_org11_test
 gidnumber: 10100
 memberuid: user830_org11_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12707,6 +12740,7 @@ dn: cn=pi_user832_org14_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user832_org14_test
 gidnumber: 10268
 memberuid: user832_org14_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12718,6 +12752,7 @@ memberuid: user379_org1_test
 memberuid: user335_org1_test
 memberuid: user701_org1_test
 memberuid: user763_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12725,6 +12760,7 @@ dn: cn=pi_user834_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user834_org2_test
 gidnumber: 10224
 memberuid: user834_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12733,6 +12769,7 @@ cn: pi_user848_org1_test
 gidnumber: 10225
 memberuid: user848_org1_test
 memberuid: user284_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12740,6 +12777,7 @@ dn: cn=pi_user849_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user849_org1_test
 gidnumber: 10160
 memberuid: user849_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12749,6 +12787,7 @@ gidnumber: 10027
 memberuid: user857_org1_test
 memberuid: user1036_org1_test
 memberuid: user708_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12757,6 +12796,7 @@ cn: pi_user859_org1_test
 gidnumber: 10158
 memberuid: user859_org1_test
 memberuid: user96_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12764,6 +12804,7 @@ dn: cn=pi_user865_org000000007_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user865_org000000007_test
 gidnumber: 10221
 memberuid: user865_org000000007_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12771,6 +12812,7 @@ dn: cn=pi_user868_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user868_org1_test
 gidnumber: 10076
 memberuid: user868_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12778,6 +12820,7 @@ dn: cn=pi_user870_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user870_org3_test
 gidnumber: 10233
 memberuid: user870_org3_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12785,6 +12828,7 @@ dn: cn=pi_user872_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user872_org1_test
 gidnumber: 10038
 memberuid: user872_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12792,6 +12836,7 @@ dn: cn=pi_user873_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user873_org2_test
 gidnumber: 10142
 memberuid: user873_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12799,6 +12844,7 @@ dn: cn=pi_user875_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user875_org1_test
 gidnumber: 10185
 memberuid: user875_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12819,6 +12865,7 @@ memberuid: user457_org1_test
 memberuid: user286_org1_test
 memberuid: user884_org1_test
 memberuid: user562_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12826,6 +12873,7 @@ dn: cn=pi_user878_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user878_org2_test
 gidnumber: 10214
 memberuid: user878_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12833,6 +12881,7 @@ dn: cn=pi_user879_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user879_org1_test
 gidnumber: 10037
 memberuid: user879_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12842,6 +12891,7 @@ gidnumber: 10086
 memberuid: user881_org1_test
 memberuid: user1203_org1_test
 memberuid: user220_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12851,6 +12901,7 @@ gidnumber: 10215
 memberuid: user882_org1_test
 memberuid: user941_org1_test
 memberuid: user238_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12860,6 +12911,7 @@ gidnumber: 10029
 memberuid: user885_org1_test
 memberuid: user742_org1_test
 memberuid: user490_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12867,6 +12919,7 @@ dn: cn=pi_user886_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user886_org1_test
 gidnumber: 10121
 memberuid: user886_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12874,6 +12927,7 @@ dn: cn=pi_user890_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user890_org3_test
 gidnumber: 10182
 memberuid: user890_org3_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12881,6 +12935,7 @@ dn: cn=pi_user905_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user905_org1_test
 gidnumber: 10272
 memberuid: user905_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12889,6 +12944,7 @@ cn: pi_user915_org1_test
 gidnumber: 10184
 memberuid: user915_org1_test
 memberuid: user431_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12896,6 +12952,7 @@ dn: cn=pi_user917_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user917_org1_test
 gidnumber: 10280
 memberuid: user917_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12903,6 +12960,7 @@ dn: cn=pi_user928_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user928_org1_test
 gidnumber: 10050
 memberuid: user928_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12910,6 +12968,7 @@ dn: cn=pi_user931_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user931_org1_test
 gidnumber: 10253
 memberuid: user931_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12920,6 +12979,7 @@ memberuid: user933_org2_test
 memberuid: user122_org2_test
 memberuid: user617_org2_test
 memberuid: user1050_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12929,6 +12989,7 @@ gidnumber: 10114
 memberuid: user935_org1_test
 memberuid: user106_org1_test
 memberuid: user115_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12937,6 +12998,7 @@ cn: pi_user936_org1_test
 gidnumber: 10061
 memberuid: user936_org1_test
 memberuid: user831_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12946,6 +13008,7 @@ gidnumber: 10171
 memberuid: user937_org1_test
 memberuid: user1195_org1_test
 memberuid: user356_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12955,6 +13018,7 @@ gidnumber: 10068
 memberuid: user938_org1_test
 memberuid: user907_org1_test
 memberuid: user1153_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12964,6 +13028,7 @@ gidnumber: 10183
 memberuid: user940_org3_test
 memberuid: user299_org3_test
 memberuid: user945_org3_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12974,6 +13039,7 @@ memberuid: user955_org2_test
 memberuid: user802_org2_test
 memberuid: user726_org2_test
 memberuid: user140_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12985,6 +13051,7 @@ memberuid: user31_org1_test
 memberuid: user454_org1_test
 memberuid: user390_org1_test
 memberuid: user1174_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12995,6 +13062,7 @@ memberuid: user962_org1_test
 memberuid: user696_org1_test
 memberuid: user350_org1_test
 memberuid: user624_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13006,6 +13074,7 @@ memberuid: user683_org1_test
 memberuid: user118_org1_test
 memberuid: user981_org1_test
 memberuid: user1159_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13013,6 +13082,7 @@ dn: cn=pi_user968_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user968_org2_test
 gidnumber: 10120
 memberuid: user968_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13025,6 +13095,7 @@ memberuid: user567_org1_test
 memberuid: user455_org1_test
 memberuid: user399_org1_test
 memberuid: user218_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13037,6 +13108,7 @@ memberuid: user408_org2_test
 memberuid: user322_org2_test
 memberuid: user375_org2_test
 memberuid: user985_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13045,6 +13117,7 @@ cn: pi_user1005_org3_test
 gidnumber: 10262
 memberuid: user1005_org3_test
 memberuid: user203_org3_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13053,6 +13126,7 @@ cn: pi_user1009_org1_test
 gidnumber: 10034
 memberuid: user1009_org1_test
 memberuid: user474_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13060,6 +13134,7 @@ dn: cn=pi_user1018_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1018_org2_test
 gidnumber: 10255
 memberuid: user1018_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13070,6 +13145,7 @@ memberuid: user1019_org3_test
 memberuid: user1138_org3_test
 memberuid: user812_org3_test
 memberuid: user646_org3_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13078,6 +13154,7 @@ cn: pi_user1022_org3_test
 gidnumber: 10163
 memberuid: user1022_org3_test
 memberuid: user159_org3_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13089,6 +13166,7 @@ memberuid: user21_org1_test
 memberuid: user161_org1_test
 memberuid: user824_org1_test
 memberuid: user447_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13097,6 +13175,7 @@ cn: pi_user1029_org1_test
 gidnumber: 10148
 memberuid: user1029_org1_test
 memberuid: user903_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13108,6 +13187,7 @@ memberuid: user1061_org1_test
 memberuid: user26_org1_test
 memberuid: user1069_org1_test
 memberuid: user79_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13115,6 +13195,7 @@ dn: cn=pi_user1039_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1039_org1_test
 gidnumber: 10256
 memberuid: user1039_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13124,6 +13205,7 @@ gidnumber: 10030
 memberuid: user1045_org1_test
 memberuid: user740_org1_test
 memberuid: user1154_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13131,6 +13213,7 @@ dn: cn=pi_user1053_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1053_org1_test
 gidnumber: 10258
 memberuid: user1053_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13138,6 +13221,7 @@ dn: cn=pi_user1056_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1056_org2_test
 gidnumber: 10270
 memberuid: user1056_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13153,6 +13237,7 @@ memberuid: user939_org1_test
 memberuid: user19_org1_test
 memberuid: user573_org1_test
 memberuid: user1090_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13163,6 +13248,7 @@ memberuid: user1076_org1_test
 memberuid: user227_org8_test
 memberuid: user1237_org1_test
 memberuid: user494_org8_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13174,6 +13260,7 @@ memberuid: user709_org2_test
 memberuid: user593_org2_test
 memberuid: user610_org2_test
 memberuid: user525_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13181,6 +13268,7 @@ dn: cn=pi_user1079_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1079_org1_test
 gidnumber: 10159
 memberuid: user1079_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13188,6 +13276,7 @@ dn: cn=pi_user1082_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1082_org1_test
 gidnumber: 10056
 memberuid: user1082_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13195,6 +13284,7 @@ dn: cn=pi_user1101_org14_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1101_org14_test
 gidnumber: 10269
 memberuid: user1101_org14_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13202,6 +13292,7 @@ dn: cn=pi_user1103_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1103_org2_test
 gidnumber: 10240
 memberuid: user1103_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13210,6 +13301,7 @@ cn: pi_user1109_org2_test
 gidnumber: 10192
 memberuid: user1109_org2_test
 memberuid: user520_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13218,6 +13310,7 @@ cn: pi_user1110_org2_test
 gidnumber: 10257
 memberuid: user1110_org2_test
 memberuid: user183_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13230,6 +13323,7 @@ memberuid: user605_org1_test
 memberuid: user1268_org1_test
 memberuid: user506_org1_test
 memberuid: user671_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13237,6 +13331,7 @@ dn: cn=pi_user1118_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1118_org1_test
 gidnumber: 10033
 memberuid: user1118_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13251,6 +13346,7 @@ memberuid: user131_org1_test
 memberuid: user1290_org1_test
 memberuid: user1197_org1_test
 memberuid: user806_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13258,13 +13354,13 @@ dn: cn=pi_user11_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user11_org1_test
 gidnumber: 10031
 memberuid: user11_org1_test
-memberuid: user1_org1_test
 memberuid: user156_org6_test
 memberuid: user222_org6_test
 memberuid: user1126_org12_test
 memberuid: user1068_org12_test
 memberuid: user686_org12_test
 memberuid: user804_org12_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13272,6 +13368,7 @@ dn: cn=pi_user1128_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1128_org1_test
 gidnumber: 10284
 memberuid: user1128_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13280,6 +13377,7 @@ cn: pi_user1129_org1_test
 gidnumber: 10189
 memberuid: user1129_org1_test
 memberuid: user861_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13287,6 +13385,7 @@ dn: cn=pi_user1130_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1130_org1_test
 gidnumber: 10117
 memberuid: user1130_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13298,13 +13397,7 @@ memberuid: user1193_org5_test
 memberuid: user1121_org5_test
 memberuid: user855_org5_test
 memberuid: user76_org5_test
-objectclass: posixGroup
-objectclass: top
-
-dn: cn=pi_user7_org1_test,ou=pi_groups,dc=unityhpc,dc=test
-cn: pi_user7_org1_test
-gidnumber: 10124
-memberuid: user7_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13314,6 +13407,7 @@ gidnumber: 10055
 memberuid: user1165_org1_test
 memberuid: user1074_org1_test
 memberuid: user1299_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13321,6 +13415,7 @@ dn: cn=pi_user1171_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1171_org1_test
 gidnumber: 10250
 memberuid: user1171_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13332,6 +13427,7 @@ memberuid: user127_org1_test
 memberuid: user1289_org1_test
 memberuid: user1163_org1_test
 memberuid: user956_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13341,6 +13437,7 @@ gidnumber: 10188
 memberuid: user1176_org1_test
 memberuid: user845_org1_test
 memberuid: user314_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13349,6 +13446,7 @@ cn: pi_user1182_org2_test
 gidnumber: 10128
 memberuid: user1182_org2_test
 memberuid: user1189_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13356,6 +13454,7 @@ dn: cn=pi_user1185_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1185_org1_test
 gidnumber: 10213
 memberuid: user1185_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13363,6 +13462,7 @@ dn: cn=pi_user1187_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1187_org1_test
 gidnumber: 10208
 memberuid: user1187_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13370,6 +13470,7 @@ dn: cn=pi_user13_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user13_org1_test
 gidnumber: 10226
 memberuid: user13_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13378,6 +13479,7 @@ cn: pi_user1191_org2_test
 gidnumber: 10231
 memberuid: user1191_org2_test
 memberuid: user594_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13385,6 +13487,7 @@ dn: cn=pi_user1201_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1201_org1_test
 gidnumber: 10249
 memberuid: user1201_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13393,6 +13496,7 @@ cn: pi_user1227_org1_test
 gidnumber: 10244
 memberuid: user1227_org1_test
 memberuid: user260_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13401,6 +13505,7 @@ cn: pi_user1233_org1_test
 gidnumber: 10273
 memberuid: user1233_org1_test
 memberuid: user465_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13408,6 +13513,7 @@ dn: cn=pi_user1234_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1234_org1_test
 gidnumber: 10282
 memberuid: user1234_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13417,6 +13523,7 @@ gidnumber: 10041
 memberuid: user1235_org3_test
 memberuid: user961_org3_test
 memberuid: user313_org3_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13434,6 +13541,7 @@ memberuid: user77_org2_test
 memberuid: user210_org2_test
 memberuid: user657_org2_test
 memberuid: user69_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13441,6 +13549,7 @@ dn: cn=pi_user1255_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1255_org1_test
 gidnumber: 10146
 memberuid: user1255_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13449,6 +13558,7 @@ cn: pi_user1260_org2_test
 gidnumber: 10043
 memberuid: user1260_org2_test
 memberuid: user1215_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13459,6 +13569,7 @@ memberuid: user1280_org1_test
 memberuid: user1183_org1_test
 memberuid: user1224_org1_test
 memberuid: user1012_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13484,6 +13595,7 @@ memberuid: user47_org1_test
 memberuid: user443_org1_test
 memberuid: user1044_org1_test
 memberuid: user255_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13492,6 +13604,7 @@ cn: pi_user1293_org2_test
 gidnumber: 10265
 memberuid: user1293_org2_test
 memberuid: user537_org2_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13499,6 +13612,7 @@ dn: cn=pi_user1298_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1298_org1_test
 gidnumber: 10210
 memberuid: user1298_org1_test
+objectclass: unityClusterPIGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -17432,8 +17546,6 @@ objectclass: ldapPublicKey
 givenname: Lori
 sn: Patterson
 gecos: Lori Patterson
-sshpublickey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDZeqDmA6wuXsB5kC2T7HTjolXQFnV8/b+O3CZcoRDzqGjmpnBERvrzjhwaHofr+4knfvrWKqg3i5s74F369PXxIXCT0f6u5Vui6/fQCBq8HP6Z7SVAoVgoZFDUotPOlP4/2CoHq1ojYMkNzBLaIkjnKdckAs692WiUAhMsExreutjFx97nEt7DAlPVaOT5HAbBhvp/EWRKdihPDatdrKJ0ji/+/sTRYdhOyNgpMkS1IEmgYUBhBLl6fwwFgwMrnYvMlWLPNNVJ/D3oXmr4dZXpYOflwSHJ/J5w0d/PFCBJgMIOJ7v76R/9siZ5VvG/Z7V/S29YCXTlPhPhPBM5K++d
-sshpublickey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCeRQtdc/3NRffyhi7LkGj9KFylzKyJNwkv1NQw7koUtB9kJ7EerHnkPIX3R6BENcqhy24sFFq7ktX8e47HqS/DbVqLgjkExM6il3s/0xWmjKD+E+wB1hxPNMazmX18/2rzkCJlNS3c9xkVM9elr9hL5RCncwaFI4HS7lwQ9ciJpaE3lGW+llA2H9F0Is2lDMVftQh/NvFg1uomfe9tJPu8cfxTQ3yg3b8MeYXLRedilhpCWCTK1theTWcsYj6S2IEXiiYRqfwSh+FHK22EytZjxVED0bWqDPRXl23oaIRfsq26uvzUT9fZz1Fh3M67SlHMRKiUqkdqanetDjf5gAih
 uid: user9_org3_test
 uidnumber: 1306
 

--- a/tools/docker-dev/identity/unity-cluster-schema.ldif
+++ b/tools/docker-dev/identity/unity-cluster-schema.ldif
@@ -1,0 +1,12 @@
+dn: cn=unityCluster,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: unityCluster
+olcAttributeTypes: ( 1.1.1 NAME 'isDefunct'
+    DESC 'if defunct, systems should pretend this group does not exist'
+    EQUALITY booleanMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+    )
+olcObjectClasses: ( 1.1.2 NAME 'unityClusterPIGroup' SUP top AUXILIARY
+    DESC 'Unity Cluster PI Group'
+    MAY ( isDefunct )
+    )

--- a/webroot/panel/modal/pi_search.php
+++ b/webroot/panel/modal/pi_search.php
@@ -10,7 +10,7 @@ if (empty($search_query)) {
     UnityHTTPD::die();
 }
 
-$assocs = $LDAP->getAllPIGroups($SQL, $MAILER, $WEBHOOK);
+$assocs = $LDAP->getAllNonDefunctPIGroups($SQL, $MAILER, $WEBHOOK);
 
 $MAX_COUNT = 10;  // Max results of PI search
 

--- a/webroot/panel/new_account.php
+++ b/webroot/panel/new_account.php
@@ -4,14 +4,22 @@ require_once __DIR__ . "/../../resources/autoload.php";
 
 use UnityWebPortal\lib\UnityHTTPD;
 use UnityWebPortal\lib\UnityUser;
+use UnityWebPortal\lib\UserFlag;
 
-if ($USER->exists()) {
+if ($USER->exists() && (!$USER->getFlag(UserFlag::GHOST))) {
     UnityHTTPD::redirect(getURL("panel/account.php"));
 }
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
     UnityHTTPD::validatePostCSRFToken();
-    $user = new UnityUser($SSO["user"], $LDAP, $SQL, $MAILER, $WEBHOOK);
-    $user->init($SSO["firstname"], $SSO["lastname"], $SSO["mail"], $SSO["org"]);
+    if ($USER->getFlag(UserFlag::GHOST)) {
+        $USER->setFlag(UserFlag::GHOST, false);
+        UnityHTTPD::messageInfo(
+            "Welcome Back!",
+            "Your previously deleted account has been resurrected."
+        );
+    } else {
+        $USER->init($SSO["firstname"], $SSO["lastname"], $SSO["mail"], $SSO["org"]);
+    }
     // header.php will redirect to this same page again and then this page will redirect to account
 }
 require $LOC_HEADER;

--- a/webroot/panel/pi.php
+++ b/webroot/panel/pi.php
@@ -33,6 +33,10 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             $group->removeUser($form_user);
 
             break;
+        case "disband":
+            $group->disband();
+            UnityHTTPD::redirect(getURL("panel/account.php"));
+            break; /** @phpstan-ignore deadCode.unreachable */
     }
 }
 
@@ -125,7 +129,21 @@ foreach ($assocs as $assoc) {
     echo "</tr>";
 }
 
-echo "</table>";
+echo "
+    </table>
+    <hr>
+    <h2>Danger Zone</h2>
+    <form
+        action=''
+        method='POST'
+        onsubmit='return confirm(\"Are you sure you want to disband your PI group?\")'
+    >
+        $CSRFTokenHiddenFormInput
+        <input type='hidden' name='form_type' value='disband'>
+        <input type='submit' value='Disband PI Account'>
+    </form>
+";
+
 ?>
 
 <?php require $LOC_FOOTER; ?>

--- a/workers/group_user_request_owner_reminder.php
+++ b/workers/group_user_request_owner_reminder.php
@@ -9,7 +9,7 @@ include __DIR__ . "/init.php";
 use UnityWebPortal\lib\UnityGroup;
 
 $today = time();
-$accounts = $LDAP->getAllPIGroups($SQL, $MAILER, $WEBHOOK);
+$accounts = $LDAP->getAllNonDefunctPIGroups($SQL, $MAILER, $WEBHOOK);
 foreach ($accounts as $pi_group) {
     $pi_user = $pi_group->getOwner();
     $requests = $pi_group->getRequests();

--- a/workers/update-qualified-users-group.php
+++ b/workers/update-qualified-users-group.php
@@ -1,0 +1,65 @@
+#!/usr/bin/env php
+<?php
+include __DIR__ . "/init.php";
+use Garden\Cli\Cli;
+
+$cli = new Cli();
+$cli->description("Add and remove users from the qualified user group.")->opt(
+    "dry-run",
+    "Print changes without actually changing anything.",
+    false,
+    "boolean",
+);
+$args = $cli->parse($argv, true);
+
+$qualified_list_before = $LDAP->userFlagGroups["qualified"]->getMemberUIDs();
+$qualified_list_after = $qualified_list_before;
+$pi_groups_attributes = $LDAP->getAllNonDefunctPIGroupsAttributes(
+    ["cn", "memberuid"],
+    ["memberuid" => []],
+);
+$uid2gids = [];
+foreach ($pi_groups_attributes as $attributes) {
+    $gid = $attributes["cn"][0];
+    foreach ($attributes["memberuid"] as $uid) {
+        if (array_key_exists($uid, $uid2gids)) {
+            array_push($uid2gids[$uid], $gid);
+        } else {
+            $uid2gids[$uid] = [$gid];
+        }
+    }
+}
+// remove users who don't exist in uid2gids
+$qualified_list_after = array_filter(
+    $qualified_list_after,
+    fn($x) => array_key_exists($x, $uid2gids),
+    ARRAY_FILTER_USE_KEY,
+);
+foreach ($uid2gids as $uid => $gids) {
+    if (count($gids) === 0) {
+        if (($i = array_search($uid, $qualified_list_after)) !== false) {
+            unset($qualified_list_after[$i]);
+        }
+    } else {
+        if (!in_array($uid, $qualified_list_after)) {
+            array_push($qualified_list_after, $uid);
+        }
+    }
+}
+$qualified_list_after = array_values($qualified_list_after);
+$users_added = array_values(array_diff($qualified_list_after, $qualified_list_before));
+$users_removed = array_values(array_diff($qualified_list_before, $qualified_list_after));
+echo jsonEncode(
+    [
+        "added" => $users_added,
+        "removed" => $users_removed,
+    ],
+    JSON_PRETTY_PRINT,
+) . "\n";
+
+if ($args["dry-run"]) {
+    echo "dry run, nothing doing.\n";
+} else {
+    $LDAP->userFlagGroups["qualified"]->overwriteMemberUIDs($qualified_list_after);
+}
+


### PR DESCRIPTION
Closes https://github.com/UnityHPC/account-portal/issues/392

Changes:
* reimplemented the "disband PI" feature, marking PI group as "defunct" and removing that mark if the PI later gets approved for another group
    * updated LDAP schema for PI groups to add the optional attribute `isDefunct`
    * updated logic to treat defunct PI groups as though they don't exist
* added logic to set the `qualified` user flag correctly in every place whenever a user is added or removed from a PI group
    * admin approve member request
    * PI approve member request
    * admin remove user from group
    * PI remove user from group
    * user remove themself from group
    * owner disband PI group (disqualify owner)
    * admin disband PI group (disqualify owner)
    * owner disband PI group (disqualify any member)
    * admin disband PI group (disqualify any member)
    * admin manually removes uid from `memberuid` attribute in PI group LDAP entry
* added logic to deny access to anyone with the `locked` flag
* added logic to remove the `idlelocked` flag whenever a user logs in and send them a message that they have unlocked
* added logic to support the re-registration of a user who previously became a ghost

TODO:
* documentation
* tests:
    - [x] ghost account is not redirected from `new_account.php` to `account.php`
    - [x] ghost account is resurrected when they register again, message is sent
    - [x] defunct PI group does not make a user a PI
    - [x] reinstating defunct PI group
    - [x] idle unlock works, message is sent
    - [x] qualify works
        - [x] admin approve
        - [x] PI approve
    - [x] dequalify works
        - [x] admin remove user
        - [x] PI remove user
        - [x] user leave group
    - [x] viewAsUser does not reset idlelock
    - [x] locked works
    - [x] disband PI group
        - [x] by admin
        - [x] by owner
    - [x] `getIsDefunct`, `setIsDefunct`
    - [x] `isDefunct` unset is treated as false
    - [x] `isDefunct` unset groups and `isDefunct=FALSE` groups are both shown in `pi-mgmt.php`
    - [x] disband PI group become unqualified
        - [x] by owner
        - [x] by admin

Future Work:
* replace "request account deletion" with instant conversion to ghost