### PR TITLE
Make the header go in front of the ssh key boxes instead of in front of them

### DIFF
--- a/webroot/css/navbar.css
+++ b/webroot/css/navbar.css
@@ -44,6 +44,7 @@ header {
   position: fixed;
   top: 0;
   left: 0;
+  z-index: 10;
 }
 
 header > #imgLogo {


### PR DESCRIPTION
I changed the z-index of the header so that when the website is in mobile mode or the screen is just narrow the key boxes don't go in front of the header.

before:
<img width="626" height="775" alt="before" src="https://github.com/user-attachments/assets/f9f15124-d171-454b-9bed-d51cf304330e" />

after:
<img width="626" height="775" alt="after" src="https://github.com/user-attachments/assets/01fc290e-50de-4a7c-9f27-6df8ad3bcab2" />
