### PR TITLE
allow multiple groups for one user flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ rm "$prod" && ln -s "$old" "$prod"
 
 ### Version-specific update instructions:
 
+### 1.6 -> 1.7
+
+- the `[ldap]user_flag_groups` option has been moved to `[ldap_user_flag_groups]`
+- each user flag group can now optionally be an array
+  - if there are multiple groups for a user flag, all groups are used to check for the flag, but only the 1st group is used to enable/disable a flag for a user
+
 ### 1.5 -> 1.6
 
 - the `[site]getting_started_url` option should be defined

--- a/defaults/config.ini.default
+++ b/defaults/config.ini.default
@@ -35,16 +35,19 @@ def_user_shell = "/bin/bash"  ; Default shell for new users
 offset_UIDGID = 1000000 ; start point when allocating new UID/GID pairs for a new user
 offset_PIGID = 2000000 ; start point when allocating new GID for a new PI group
 offset_ORGGID = 3000000 ; start point when allocating new GID for a new org group
-user_flag_groups[admin] =      "cn=web_admins,dc=unityhpc,dc=test" ; admin user group dn
-user_flag_groups[ghost] =      "cn=ghost,dc=unityhpc,dc=test"      ; ghost user group dn
-user_flag_groups[idlelocked] = "cn=idlelocked,dc=unityhpc,dc=test" ; idlelocked user group dn
-user_flag_groups[locked] =     "cn=locked,dc=unityhpc,dc=test"     ; locked user group dn
-user_flag_groups[qualified] =  "cn=unityusers,dc=unityhpc,dc=test" ; qualified user group (in at least one PI group)
 allowed_ssh_key_types[] = ssh-rsa
 allowed_ssh_key_types[] = ecdsa-sha2-nistp256
 allowed_ssh_key_types[] = ecdsa-sha2-nistp384
 allowed_ssh_key_types[] = ecdsa-sha2-nistp521
 allowed_ssh_key_types[] = ssh-ed25519
+
+[ldap_user_flag_groups]
+admin =      "cn=web_admins,dc=unityhpc,dc=test" ; admin user group dn
+ghost =      "cn=ghost,dc=unityhpc,dc=test"      ; ghost user group dn
+idlelocked = "cn=idlelocked,dc=unityhpc,dc=test" ; idlelocked user group dn
+locked =     "cn=locked,dc=unityhpc,dc=test"     ; locked user group dn
+qualified[] =  "cn=unityusers,dc=unityhpc,dc=test" ; qualified user group
+qualified[] =  "cn=extra_qualifed,dc=unityhpc,dc=test" ; extra qualified user group
 
 [sql]
 host = "sql"  ; mariadb hostname

--- a/resources/lib/UnityLDAP.php
+++ b/resources/lib/UnityLDAP.php
@@ -58,8 +58,14 @@ class UnityLDAP extends LDAPConn
         $this->org_groupOU = $this->getEntry(CONFIG["ldap"]["orggroup_ou"]);
         $this->userFlagGroups = [];
         foreach (UserFlag::cases() as $flag) {
-            $dn = CONFIG["ldap"]["user_flag_groups"][$flag->value];
-            $this->userFlagGroups[$flag->value] = new PosixGroup(new LDAPEntry($this->conn, $dn));
+            $this->userFlagGroups[$flag->value] = [];
+            $DNs = (array) CONFIG["ldap_user_flag_groups"][$flag->value];
+            foreach ($DNs as $dn) {
+                array_push(
+                    $this->userFlagGroups[$flag->value],
+                    new PosixGroup(new LDAPEntry($this->conn, $dn)),
+                );
+            }
         }
     }
 

--- a/resources/lib/UnityUser.php
+++ b/resources/lib/UnityUser.php
@@ -90,7 +90,12 @@ class UnityUser
 
     public function getFlag(UserFlag $flag): bool
     {
-        return $this->LDAP->userFlagGroups[$flag->value]->memberUIDExists($this->uid);
+        foreach ($this->LDAP->userFlagGroups[$flag->value] as $group) {
+            if ($group->memberUIDExists($this->uid)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public function setFlag(
@@ -104,7 +109,7 @@ class UnityUser
             return;
         }
         if ($newValue) {
-            $this->LDAP->userFlagGroups[$flag->value]->addMemberUID($this->uid);
+            $this->LDAP->userFlagGroups[$flag->value][0]->addMemberUID($this->uid);
             if ($doSendMail) {
                 $this->MAILER->sendMail($this->getMail(), "user_flag_added", [
                     "user" => $this->uid,
@@ -120,7 +125,7 @@ class UnityUser
                 ]);
             }
         } else {
-            $this->LDAP->userFlagGroups[$flag->value]->removeMemberUID($this->uid);
+            $this->LDAP->userFlagGroups[$flag->value][0]->removeMemberUID($this->uid);
             if ($doSendMail) {
                 $this->MAILER->sendMail($this->getMail(), "user_flag_removed", [
                     "user" => $this->uid,


### PR DESCRIPTION
I thought I might need this to make the new qualify/disqualify policy place nice with production, but I was able to get them to play nice by adding stragglers to various PI groups.