### PR TITLE
tweak death message

### DIFF
--- a/resources/lib/UnityHTTPD.php
+++ b/resources/lib/UnityHTTPD.php
@@ -66,7 +66,7 @@ class UnityHTTPD
     ): never {
         $errorid = uniqid();
         $suffix = sprintf(
-            "Please notify a Unity admin at %s. Error ID: %s.",
+            "For assistance, contact a Unity admin at %s. Error ID: %s.",
             CONFIG["mail"]["support"],
             $errorid,
         );


### PR DESCRIPTION
"please notify an admin" isn't really appropriate in the case of `UnityHTTPD::forbidden()`.