### PR TITLE
fix errors from test functions http_get http_post

### DIFF
--- a/test/functional/PageLoadTest.php
+++ b/test/functional/PageLoadTest.php
@@ -64,10 +64,10 @@ class PageLoadTest extends UnityWebPortalTestCase
     }
 
     #[DataProvider("providerMisc")]
-    public function testLoadPage($nickname, $path, $regex, $expect_die = false)
+    public function testLoadPage($nickname, $path, $regex, $ignore_die = false)
     {
         $this->switchUser($nickname);
-        $output = http_get(__DIR__ . "/../../webroot/" . $path, expect_die: $expect_die);
+        $output = http_get(__DIR__ . "/../../webroot/" . $path, ignore_die: $ignore_die);
         $this->assertMatchesRegularExpression($regex, $output);
     }
 
@@ -75,7 +75,7 @@ class PageLoadTest extends UnityWebPortalTestCase
     public function testLoadAdminPageNotAnAdmin($path)
     {
         $this->switchUser("Blank");
-        $output = http_get($path, expect_die: true);
+        $output = http_get($path, ignore_die: true);
         $this->assertMatchesRegularExpression("/You are not an admin\./", $output);
     }
 
@@ -83,7 +83,7 @@ class PageLoadTest extends UnityWebPortalTestCase
     public function testLoadPageNonexistentUser($path)
     {
         $this->switchUser("NonExistent");
-        $output = http_get($path, expect_die: true);
+        $output = http_get($path, ignore_die: true);
         $this->assertMatchesRegularExpression("/panel\/new_account\.php/", $output);
     }
 }

--- a/test/phpunit-bootstrap.php
+++ b/test/phpunit-bootstrap.php
@@ -98,7 +98,7 @@ function http_post(string $phpfile, array $post_data, bool $do_generate_csrf_tok
     }
 }
 
-function http_get(string $phpfile, array $get_data = [], bool $expect_die = false): string
+function http_get(string $phpfile, array $get_data = [], bool $ignore_die = false): string
 {
     global $LDAP, $SQL, $MAILER, $WEBHOOK, $GITHUB, $SITE, $SSO, $USER, $LOC_HEADER, $LOC_FOOTER;
     $_PREVIOUS_SERVER = $_SERVER;
@@ -111,7 +111,7 @@ function http_get(string $phpfile, array $get_data = [], bool $expect_die = fals
         include $phpfile;
         return ob_get_clean();
     } catch (UnityWebPortal\lib\exceptions\NoDieException $e) {
-        if ($expect_die) {
+        if ($ignore_die) {
             return ob_get_clean();
         } else {
             ob_get_clean(); // discard output


### PR DESCRIPTION
A few days ago I ran into a problem where the exception handler was converting an uncaught exception into a redirect. This behavior is only meant to happen when the user is doing an HTTP POST. It turns out that a previous test had polluted the `$_POST` superglobal and was not cleaned up. So I made https://github.com/UnityHPC/account-portal/commit/17a6f48a77153654b48c4a1c3113f31a7021bd14 to unset `$_SERVER["REQUEST_METHOD"]` each time you switch user. This was wrong and it also didn't actually fix the source of the pollution. Then I made https://github.com/UnityHPC/account-portal/commit/21bea0b89b700946d36eff534f635b7fb576c7d8 in an attempt to actually fix the source of the pollution, but it was still wrong. `$_SERVER` had always been cleaned up properly in `http_get` and `http_post`. The actual problem was in `AjaxSshValidateTest` where I hacked together another implementation of `http_post` (without proper cleanup) in order to capture the output. So then I made https://github.com/UnityHPC/account-portal/commit/47e99705078d26422cc2abe6fa2f418744b5eb83 to extend `http_post` to capture the output. This created another bug because if you `return` inside a `finally` you discard the thrown exception (duh). So now I am making this PR, to rewrite `http_post` and `http_get` to make sure output buffering is always stopped and make sure unexpected exceptions are never surpressed.

This got confusing because `http_post` is using `try`/`catch` for 3 different things: to assert that `NoDieException` is thrown, to capture output, and to avoid polluting globals. I turned it into a nested `try`/`catch` because that was easier for me to wrap my head around, but it's ugly.

I tried to make it so that output was not discarded on failure, but this causes unnecessary spam in stdout when an exception is thrown that was intentional and is going to be caught higher in the call stack.

I didn't like how `http_get` would ignore any `NoDieException`, since it's not a very specific exception. So I added a parameter `ignore_die`, so by default it does not ignore `NoDieException`. Where `ignore_die` is used currently, there are assertions that make sure it was the right type of death.