### PR TITLE
add user flags to user-mgmt.php 2

### DIFF
--- a/webroot/admin/user-mgmt.php
+++ b/webroot/admin/user-mgmt.php
@@ -21,6 +21,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 
 require getTemplatePath("header.php");
 $CSRFTokenHiddenFormInput = UnityHTTPD::getCSRFTokenHiddenFormInput();
+$flags_to_display = array_filter(UserFlag::cases(), fn($x) => $x !== UserFlag::DISABLED);
 ?>
 
 <h1>User Management</h1>
@@ -38,7 +39,7 @@ $CSRFTokenHiddenFormInput = UnityHTTPD::getCSRFTokenHiddenFormInput();
             <th>Mail</th>
             <th>Groups</th>
             <th>Actions</th>
-<?php foreach (UserFlag::cases() as $flag) : ?>
+<?php foreach ($flags_to_display as $flag) : ?>
             <th><?php echo $flag->value; ?></th>
 <?php endforeach ?>
         </tr>
@@ -61,6 +62,9 @@ $CSRFTokenHiddenFormInput = UnityHTTPD::getCSRFTokenHiddenFormInput();
     usort($user_attributes, fn ($a, $b) => strcmp($a["uid"][0], $b["uid"][0]));
     foreach ($user_attributes as $attributes) {
         $uid = $attributes["uid"][0];
+        if (in_array($uid, $users_with_flags[UserFlag::DISABLED->value])) {
+            continue;
+        }
         if ($SQL->accDeletionRequestExists($uid)) {
             echo "<tr style='color:#555555; font-style: italic'>";
         } else {
@@ -88,7 +92,7 @@ $CSRFTokenHiddenFormInput = UnityHTTPD::getCSRFTokenHiddenFormInput();
         <input type='submit' name='action' value='Access'>
         </form>";
         echo "</td>";
-        foreach (UserFlag::cases() as $flag) {
+        foreach ($flags_to_display as $flag) {
             echo sprintf(
                 "<td>%s</td>",
                 in_array($uid, $users_with_flags[$flag->value]) ? $flag->value : ""
@@ -112,7 +116,7 @@ $(document).ready(() => {
             {responsivePriority: 2, render: dataTablesRenderMailtoLink}, // mail
             {responsivePriority: 3, searchable: false}, // groups
             {responsivePriority: 1, searchable: false}, // actions
-<?php foreach (UserFlag::cases() as $flag) : ?>
+<?php foreach ($flags_to_display as $flag) : ?>
             {visible: false}, // <?php echo $flag->value . "\n"?>
 <?php endforeach ?>
         ],


### PR DESCRIPTION
Also hides disabled users from user-mgmt table.

All new columns are hidden by default.

example: find locked users by sorting the table by the `locked` column:

<img width="1050" height="557" alt="image" src="https://github.com/user-attachments/assets/015e4265-135b-4f68-86a0-698ef621cce1" />

html generated:

<img width="276" height="272" alt="image" src="https://github.com/user-attachments/assets/1a0a52ca-c80b-4925-b316-395ec65d9927" />

javascript generated:

<img width="558" height="335" alt="image" src="https://github.com/user-attachments/assets/978fd091-3db7-41b2-aa66-9a104eb160f9" />

