### PR TITLE
show owner in member list

### DIFF
--- a/webroot/panel/pi.php
+++ b/webroot/panel/pi.php
@@ -122,13 +122,14 @@ echo "
         <tbody>
 ";
 
+$owner_uid = $group->getOwner()->uid;
 foreach ($assocs as $assoc) {
     echo "<tr>";
     echo "<td>" . $assoc->getFirstname() . " " . $assoc->getLastname() . "</td>";
     echo "<td>" . $assoc->uid . "</td>";
     echo "<td>" . $assoc->getMail() . "</td>";
     echo "<td>";
-    $disabled = $assoc->uid === $USER->uid ? "disabled" : "";
+    $disabled = $assoc->uid === $owner_uid ? "disabled" : "";
     echo
         "<form action='' method='POST'>
     $CSRFTokenHiddenFormInput


### PR DESCRIPTION
I am adding PI group managers (https://github.com/UnityHPC/account-portal/pull/567). When a manager accesses a page, they cannot see themself. This is because `pi.php` tries to hide the group owner. I don't think hiding the group owner is necessary. The "Remove" button is disabled for the group owner, since that would throw an exception.

<img width="1110" height="665" alt="image" src="https://github.com/user-attachments/assets/8841ce37-d2b3-4e29-8932-3fd3e0d363f7" />
