### PR TITLE
PI group managers

### DIFF
--- a/LDAP.md
+++ b/LDAP.md
@@ -23,3 +23,7 @@ Terminology:
   - if the owner is disabled, their group is also disabled
   - `memberuid` attribute should be empty
   - if you have any integrations (ex: updating slurm account DB), they should take care to ignore these PI groups
+- **association**: a user is _associated_ with a PI group (and vice versa) if they are the owner, a member, or a manager
+- **manager**: a user who has been granted authority over a PI group
+  - a manager must also be a member
+  - TODO there is no GUI for a PI to promote a user to manager, only an admin can do it

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -53,6 +53,7 @@ parameters:
         - '#If condition is always false\.#'
       paths:
         - test/functional/PIBecomeDenyTest.php
+        - webroot/panel/pi.php
     # $Subject is written by mail templates
     - messages:
         - '#Property UnityWebPortal\\lib\\UnityWebhook::\$Subject is never written, only read\.#'

--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -3,6 +3,7 @@
 namespace UnityWebPortal\lib;
 
 use Exception;
+use UnityWebPortal\lib\exceptions\EntryNotFoundException;
 
 /**
  * Class that represents a single PI group in the UnityHPC Platform.
@@ -430,5 +431,34 @@ class UnityGroup extends PosixGroup
     private function setIsDisabled(bool $new_value): void
     {
         $this->entry->setAttribute("isDisabled", $new_value ? "TRUE" : "FALSE");
+    }
+
+    public function addManagerUID(string $uid): void
+    {
+        $new_manager = new UnityUser($uid, $this->LDAP, $this->SQL, $this->MAILER, $this->WEBHOOK);
+        if (!$new_manager->exists()) {
+            throw new EntryNotFoundException("user '$uid' does not exist!");
+        }
+        $member_uids = $this->getMemberUIDs();
+        if (!in_array($uid, $member_uids)) {
+            throw new Exception("user '$uid' is not a group member!");
+        }
+        $this->entry->appendAttribute("managerUid", $uid);
+    }
+
+    public function removeManagerUID(string $uid): void
+    {
+        $this->entry->removeAttributeEntryByValue("managerUid", $uid);
+    }
+
+    public function managerUIDExists(string $uid): bool
+    {
+        return in_array($uid, $this->entry->getAttribute("managerUid"));
+    }
+
+    /** @return string[] */
+    public function getManagerUIDs(): array
+    {
+        return $this->entry->getAttribute("managerUid");
     }
 }

--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -461,4 +461,12 @@ class UnityGroup extends PosixGroup
     {
         return $this->entry->getAttribute("managerUid");
     }
+
+    public function removeMemberUID(string $uid): void
+    {
+        if ($this->managerUIDExists($uid)) {
+            $this->removeManagerUID($uid);
+        }
+        parent::removeMemberUID($uid);
+    }
 }

--- a/resources/lib/UnityLDAP.php
+++ b/resources/lib/UnityLDAP.php
@@ -245,6 +245,23 @@ class UnityLDAP extends LDAPConn
     }
 
     /** @return string[] */
+    public function getNonDisabledPIGroupGIDsWithManagerUID(string $uid): array
+    {
+        return array_map(
+            fn($x) => $x["cn"][0],
+            $this->pi_groupOU->getChildrenArrayStrict(
+                ["cn"],
+                false,
+                sprintf(
+                    "(&(manageruid=%s)%s)",
+                    ldap_escape($uid, flags: LDAP_ESCAPE_FILTER),
+                    self::$NON_DISABLED_FILTER,
+                ),
+            ),
+        );
+    }
+
+    /** @return string[] */
     public function getAllNonDisabledPIGroupOwnerUIDs(): array
     {
         return array_map(
@@ -372,16 +389,5 @@ class UnityLDAP extends LDAPConn
         }
         ksort($output);
         return $output;
-    }
-
-    /** @return string[] */
-    public function getPIGroupGIDSWithManager(string $uid): array
-    {
-        $attributes = $this->pi_groupOU->getChildrenArrayStrict(
-            ["cn"],
-            false,
-            sprintf("(managerUid=%s)", ldap_escape($uid, flags: LDAP_ESCAPE_FILTER)),
-        );
-        return array_map(fn($x) => $x["cn"][0], $attributes);
     }
 }

--- a/resources/lib/UnityLDAP.php
+++ b/resources/lib/UnityLDAP.php
@@ -373,4 +373,15 @@ class UnityLDAP extends LDAPConn
         ksort($output);
         return $output;
     }
+
+    /** @return string[] */
+    public function getPIGroupGIDSWithManager(string $uid): array
+    {
+        $attributes = $this->pi_groupOU->getChildrenArrayStrict(
+            ["cn"],
+            false,
+            sprintf("(managerUid=%s)", ldap_escape($uid, flags: LDAP_ESCAPE_FILTER)),
+        );
+        return array_map(fn($x) => $x["cn"][0], $attributes);
+    }
 }

--- a/resources/templates/header.php
+++ b/resources/templates/header.php
@@ -108,7 +108,7 @@ if (isset($SSO)) {
 
         if (isset($_SESSION["is_pi"]) && $_SESSION["is_pi"]) {
             // PI only pages
-            echo getHyperlink("My Users", "panel/pi.php") . "\n";
+            echo getHyperlink("PI Group Management", "panel/pi.php") . "\n";
         }
 
         // additional branding items

--- a/resources/templates/header.php
+++ b/resources/templates/header.php
@@ -110,6 +110,9 @@ if (isset($SSO)) {
             // PI only pages
             echo getHyperlink("My Users", "panel/pi.php") . "\n";
         }
+        foreach ($LDAP->getPIGroupGIDSWithManager($USER->uid) as $gid) {
+            echo getHyperlink("PI Group '$gid'", "panel/pi.php?gid=$gid") . "\n";
+        }
 
         // additional branding items
         $num_additional_items = count(CONFIG["menuitems_secure"]["labels"]);

--- a/resources/templates/header.php
+++ b/resources/templates/header.php
@@ -110,9 +110,6 @@ if (isset($SSO)) {
             // PI only pages
             echo getHyperlink("My Users", "panel/pi.php") . "\n";
         }
-        foreach ($LDAP->getPIGroupGIDSWithManager($USER->uid) as $gid) {
-            echo getHyperlink("PI Group '$gid'", "panel/pi.php?gid=$gid") . "\n";
-        }
 
         // additional branding items
         $num_additional_items = count(CONFIG["menuitems_secure"]["labels"]);

--- a/resources/templates/header.php
+++ b/resources/templates/header.php
@@ -108,7 +108,7 @@ if (isset($SSO)) {
 
         if (isset($_SESSION["is_pi"]) && $_SESSION["is_pi"]) {
             // PI only pages
-            echo getHyperlink("PI Group Management", "panel/pi.php") . "\n";
+            echo getHyperlink("My Users", "panel/pi.php") . "\n";
         }
 
         // additional branding items

--- a/test/functional/PIDisableTest.php
+++ b/test/functional/PIDisableTest.php
@@ -1,6 +1,7 @@
 <?php
 use UnityWebPortal\lib\UnityHTTPDMessageLevel;
 use UnityWebPortal\lib\UserFlag;
+use UnityWebPortal\lib\UnityGroup;
 
 class PIDisableTest extends UnityWebPortalTestCase
 {
@@ -52,6 +53,28 @@ class PIDisableTest extends UnityWebPortalTestCase
             $entry->setAttribute("isDisabled", "FALSE");
             $pi_group->getOwner()->setFlag(UserFlag::QUALIFIED, true);
         }
+    }
+
+    public function testDisableGroupByManager()
+    {
+        global $USER, $LDAP, $SQL, $MAILER, $WEBHOOK;
+        $this->switchUser("CourseGroupManager");
+        $managed_groups = $LDAP->getNonDisabledPIGroupGIDsWithManagerUID($USER->uid);
+        $this->assertNotEmpty($managed_groups);
+        $gid = $managed_groups[0];
+        $group = new UnityGroup($gid, $LDAP, $SQL, $MAILER, $WEBHOOK);
+        $this->assertFalse($group->getIsDisabled());
+        http_post(
+            __DIR__ . "/../../webroot/panel/pi.php",
+            ["form_type" => "disable"],
+            ["gid" => $gid],
+        );
+        $this->assertMessageExists(
+            UnityHTTPDMessageLevel::ERROR,
+            "/Permission denied/",
+            "/Only the group owner can disable/",
+        );
+        $this->assertFalse($group->getIsDisabled());
     }
 
     public function testMemberBecomesUnqualified()

--- a/test/functional/PIRemoveUserTest.php
+++ b/test/functional/PIRemoveUserTest.php
@@ -2,6 +2,7 @@
 
 use UnityWebPortal\lib\UnityUser;
 use UnityWebPortal\lib\UserFlag;
+use UnityWebPortal\lib\UnityGroup;
 use TRegx\PhpUnit\DataProviders\DataProvider as TRegxDataProvider;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -111,6 +112,31 @@ class PIRemoveUserTest extends UnityWebPortalTestCase
             }
             if (!$group->managerUIDExists($manager_uid)) {
                 $group->addManagerUID($manager_uid);
+            }
+        }
+    }
+
+    public function testManagerRemovesThemselfRedirectsToGroups()
+    {
+        global $USER, $LDAP, $SQL, $MAILER, $WEBHOOK;
+        $this->switchUser("CourseGroupManager");
+        $managed_groups = $LDAP->getNonDisabledPIGroupGIDsWithManagerUID($USER->uid);
+        $this->assertNotEmpty($managed_groups);
+        $gid = $managed_groups[0];
+        $group = new UnityGroup($gid, $LDAP, $SQL, $MAILER, $WEBHOOK);
+        try {
+            $output = http_post(
+                __DIR__ . "/../../webroot/panel/pi.php",
+                ["form_type" => "remUser", "uid" => $USER->uid],
+                ["gid" => $gid],
+            );
+            $this->assertMatchesRegularExpression("/panel\/groups\.php/", $output);
+        } finally {
+            if (!$group->memberUIDExists($USER->uid)) {
+                $group->addMemberUID($USER->uid);
+            }
+            if (!$group->managerUIDExists($USER->uid)) {
+                $group->addManagerUID($USER->uid);
             }
         }
     }

--- a/test/functional/PIRemoveUserTest.php
+++ b/test/functional/PIRemoveUserTest.php
@@ -92,4 +92,26 @@ class PIRemoveUserTest extends UnityWebPortalTestCase
             }
         }
     }
+
+    public function testRemoveMemberAlsoRemovesManager()
+    {
+        global $USER;
+        $this->switchUser("CourseGroupOwner");
+        $group = $USER->getPIGroup();
+        $manager_uids = $group->getManagerUIDs();
+        $this->assertNotEmpty($manager_uids);
+        $manager_uid = $manager_uids[0];
+        try {
+            $group->removeMemberUID($manager_uid);
+            $this->assertFalse($group->memberUIDExists($manager_uid));
+            $this->assertFalse($group->managerUIDExists($manager_uid));
+        } finally {
+            if (!$group->memberUIDExists($manager_uid)) {
+                $group->addMemberUID($manager_uid);
+            }
+            if (!$group->managerUIDExists($manager_uid)) {
+                $group->addManagerUID($manager_uid);
+            }
+        }
+    }
 }

--- a/test/functional/PageLoadTest.php
+++ b/test/functional/PageLoadTest.php
@@ -122,7 +122,7 @@ class PageLoadTest extends UnityWebPortalTestCase
             ["gid" => $gid],
             ignore_die: true,
         );
-        $this->assertMatchesRegularExpression("/not allowed/", $output);
+        $this->assertMatchesRegularExpression("/You cannot manage this group/", $output);
     }
 
     public function testLoadPIPageForNonexistentGroup()
@@ -140,7 +140,7 @@ class PageLoadTest extends UnityWebPortalTestCase
     {
         $this->switchUser("ReenabledOwnerOfDisabledPIGroup");
         $output = http_get(__DIR__ . "/../../webroot/panel/pi.php", ignore_die: true);
-        $this->assertMatchesRegularExpression("/You are not a PI/", $output);
+        $this->assertMatchesRegularExpression("/This group is disabled/", $output);
     }
 
     public function testLoadPIPageForAnotherDisabledGroup()

--- a/test/functional/PageLoadTest.php
+++ b/test/functional/PageLoadTest.php
@@ -142,9 +142,9 @@ class PageLoadTest extends UnityWebPortalTestCase
         $this->switchUser("CourseGroupManager");
         $gids = $LDAP->getPIGroupGIDSWithManager($USER->uid);
         $this->assertTrue(count($gids) > 0);
-        $output = http_get(__DIR__ . "/../../webroot/index.php");
+        $output = http_get(__DIR__ . "/../../webroot/panel/groups.php");
         foreach ($gids as $gid) {
-            $this->assertMatchesRegularExpression("/pi\.php\?gid=$gid/", $output);
+            $this->assertMatchesRegularExpression("/name='gid' value='$gid'/", $output);
         }
     }
 }

--- a/test/functional/PageLoadTest.php
+++ b/test/functional/PageLoadTest.php
@@ -53,7 +53,7 @@ class PageLoadTest extends UnityWebPortalTestCase
             ["NonExistent", "panel/new_account.php", "/Register New Account/"],
             ["Blank", "panel/account.php", "/Account Settings/"],
             ["Blank", "panel/groups.php", "/My Principal Investigators/"],
-            ["EmptyPIGroupOwner", "panel/pi.php", "/My Users/"],
+            ["EmptyPIGroupOwner", "panel/pi.php", "/PI Group Management/"],
             // new_account.php should redirect to account.php if account already exists
             ["Blank", "panel/new_account.php", "/panel\/account\.php/", true],
             // non-PI can't access pi.php
@@ -108,7 +108,7 @@ class PageLoadTest extends UnityWebPortalTestCase
         $output = http_get(__DIR__ . "/../../webroot/panel/pi.php", [
             "gid" => $gids[0],
         ]);
-        $this->assertMatchesRegularExpression("/My Users/", $output);
+        $this->assertMatchesRegularExpression("/PI Group Management/", $output);
     }
 
     public function testLoadPIPageForAnotherGroupForbidden()

--- a/test/functional/PageLoadTest.php
+++ b/test/functional/PageLoadTest.php
@@ -136,6 +136,24 @@ class PageLoadTest extends UnityWebPortalTestCase
         $this->assertMatchesRegularExpression("/This group does not exist/", $output);
     }
 
+    public function testLoadPIPageForDisabledGroup()
+    {
+        $this->switchUser("ReenabledOwnerOfDisabledPIGroup");
+        $output = http_get(__DIR__ . "/../../webroot/panel/pi.php", ignore_die: true);
+        $this->assertMatchesRegularExpression("/You are not a PI/", $output);
+    }
+
+    public function testLoadPIPageForAnotherDisabledGroup()
+    {
+        $this->switchUser("DisabledPIGroup_user9_org3_test_Manager");
+        $output = http_get(
+            __DIR__ . "/../../webroot/panel/pi.php",
+            ["gid" => "pi_user9_org3_test"],
+            ignore_die: true,
+        );
+        $this->assertMatchesRegularExpression("/This group is disabled/", $output);
+    }
+
     public function testDisplayManagedGroups()
     {
         global $USER, $LDAP;

--- a/test/functional/PageLoadTest.php
+++ b/test/functional/PageLoadTest.php
@@ -103,7 +103,7 @@ class PageLoadTest extends UnityWebPortalTestCase
     {
         global $LDAP, $USER;
         $this->switchUser("CourseGroupManager");
-        $gids = $LDAP->getPIGroupGIDSWithManager($USER->uid);
+        $gids = $LDAP->getNonDisabledPIGroupGIDsWithManagerUID($USER->uid);
         $this->assertTrue(count($gids) > 0);
         $output = http_get(__DIR__ . "/../../webroot/panel/pi.php", [
             "gid" => $gids[0],
@@ -140,7 +140,7 @@ class PageLoadTest extends UnityWebPortalTestCase
     {
         global $USER, $LDAP;
         $this->switchUser("CourseGroupManager");
-        $gids = $LDAP->getPIGroupGIDSWithManager($USER->uid);
+        $gids = $LDAP->getNonDisabledPIGroupGIDsWithManagerUID($USER->uid);
         $this->assertTrue(count($gids) > 0);
         $output = http_get(__DIR__ . "/../../webroot/panel/groups.php");
         foreach ($gids as $gid) {

--- a/test/functional/PageLoadTest.php
+++ b/test/functional/PageLoadTest.php
@@ -53,7 +53,7 @@ class PageLoadTest extends UnityWebPortalTestCase
             ["NonExistent", "panel/new_account.php", "/Register New Account/"],
             ["Blank", "panel/account.php", "/Account Settings/"],
             ["Blank", "panel/groups.php", "/My Principal Investigators/"],
-            ["EmptyPIGroupOwner", "panel/pi.php", "/PI Group Management/"],
+            ["EmptyPIGroupOwner", "panel/pi.php", "/My Users/"],
             // new_account.php should redirect to account.php if account already exists
             ["Blank", "panel/new_account.php", "/panel\/account\.php/", true],
             // non-PI can't access pi.php
@@ -105,10 +105,11 @@ class PageLoadTest extends UnityWebPortalTestCase
         $this->switchUser("CourseGroupManager");
         $gids = $LDAP->getNonDisabledPIGroupGIDsWithManagerUID($USER->uid);
         $this->assertTrue(count($gids) > 0);
+        $gid = $gids[0];
         $output = http_get(__DIR__ . "/../../webroot/panel/pi.php", [
-            "gid" => $gids[0],
+            "gid" => $gid,
         ]);
-        $this->assertMatchesRegularExpression("/PI Group Management/", $output);
+        $this->assertMatchesRegularExpression("/PI Group '$gid'/", $output);
     }
 
     public function testLoadPIPageForAnotherGroupForbidden()

--- a/test/functional/PageLoadTest.php
+++ b/test/functional/PageLoadTest.php
@@ -102,7 +102,7 @@ class PageLoadTest extends UnityWebPortalTestCase
     public function testLoadPIPageForAnotherGroup()
     {
         global $LDAP, $USER;
-        $this->switchUser("Manager");
+        $this->switchUser("CourseGroupManager");
         $gids = $LDAP->getPIGroupGIDSWithManager($USER->uid);
         $this->assertTrue(count($gids) > 0);
         $output = http_get(__DIR__ . "/../../webroot/panel/pi.php", [
@@ -139,7 +139,7 @@ class PageLoadTest extends UnityWebPortalTestCase
     public function testDisplayManagedGroups()
     {
         global $USER, $LDAP;
-        $this->switchUser("Manager");
+        $this->switchUser("CourseGroupManager");
         $gids = $LDAP->getPIGroupGIDSWithManager($USER->uid);
         $this->assertTrue(count($gids) > 0);
         $output = http_get(__DIR__ . "/../../webroot/index.php");

--- a/test/functional/WorkerUnityCourseTest.php
+++ b/test/functional/WorkerUnityCourseTest.php
@@ -5,15 +5,15 @@ class WorkerUnityCourseTest extends UnityWebPortalTestCase
     private static string $course_owner_uid = "cs124_org1_test";
     private static string $course_gid = "pi_cs124_org1_test";
     private static array $course_owner_name = ["cs124", "Fall 2025"];
-    private static string $manager_uid = "user12_org1_test";
-    private static string $manager_mail = "user12@org1.test";
-    private static string $courseOwnerMail = "user12+cs124_org1_test@org1.test";
+    private static string $manager_uid = "user2_org1_test";
+    private static string $manager_mail = "user2@org1.test";
+    private static string $courseOwnerMail = "user2+cs124_org1_test@org1.test";
 
     public function testCreateCourse()
     {
         global $LDAP, $USER;
-        $this->switchUser("CourseWorkerTestManager");
-        $this->assertEquals(self::$manager_mail, $USER->getMail());
+        $this->switchUser("Blank");
+        $this->assertEquals(self::$manager_uid, $USER->uid);
         $this->assertEquals(self::$manager_mail, $USER->getMail());
         $manager = $USER;
         $pi_group_entry = $LDAP->getPIGroupEntry(self::$course_gid);

--- a/test/functional/WorkerUnityCourseTest.php
+++ b/test/functional/WorkerUnityCourseTest.php
@@ -2,16 +2,30 @@
 
 class WorkerUnityCourseTest extends UnityWebPortalTestCase
 {
+    private static string $course_owner_uid = "cs124_org1_test";
+    private static string $course_gid = "pi_cs124_org1_test";
+    private static array $course_owner_name = ["cs124", "Fall 2025"];
+    private static string $manager_uid = "user12_org1_test";
+    private static string $manager_mail = "user12@org1.test";
+    private static string $courseOwnerMail = "user12+cs124_org1_test@org1.test";
+
     public function testCreateCourse()
     {
         global $LDAP, $USER;
         $this->switchUser("CourseWorkerTestManager");
+        $this->assertEquals(self::$manager_mail, $USER->getMail());
+        $this->assertEquals(self::$manager_mail, $USER->getMail());
         $manager = $USER;
-        $pi_group_entry = $LDAP->getPIGroupEntry("pi_cs124_org1_test");
-        $owner_user_entry = $LDAP->getUserEntry("cs124_org1_test");
+        $pi_group_entry = $LDAP->getPIGroupEntry(self::$course_gid);
+        $owner_user_entry = $LDAP->getUserEntry(self::$course_owner_uid);
         $this->assertFalse($pi_group_entry->exists());
         $this->assertFalse($owner_user_entry->exists());
-        $stdin_file = writeLinesToTmpFile(["cs124", "Fall 2025", "cs124_org1_test", $manager->uid]);
+        $stdin_file = writeLinesToTmpFile([
+            self::$course_owner_name[0],
+            self::$course_owner_name[1],
+            self::$course_owner_uid,
+            self::$manager_uid,
+        ]);
         $stdin_file_path = getPathFromFileHandle($stdin_file);
         try {
             executeWorker("unity-course.php", stdinFilePath: $stdin_file_path);
@@ -19,13 +33,13 @@ class WorkerUnityCourseTest extends UnityWebPortalTestCase
             // our LDAP conn doesn't know about changes from subprocess
             unset($GLOBALS["ldapconn"]);
             $this->switchUser("Admin");
-            $pi_group_entry = $LDAP->getPIGroupEntry("pi_cs124_org1_test");
-            $owner_user_entry = $LDAP->getUserEntry("cs124_org1_test");
+            $pi_group_entry = $LDAP->getPIGroupEntry(self::$course_gid);
+            $owner_user_entry = $LDAP->getUserEntry(self::$course_owner_uid);
             $this->assertTrue($pi_group_entry->exists());
             $this->assertTrue($owner_user_entry->exists());
-            $this->assertEquals($manager->getMail(), $owner_user_entry->getAttribute("mail")[0]);
+            $this->assertEquals(self::$courseOwnerMail, $owner_user_entry->getAttribute("mail")[0]);
             $this->assertEqualsCanonicalizing(
-                ["cs124_org1_test", $manager->uid],
+                [self::$course_owner_uid, $manager->uid],
                 $pi_group_entry->getAttribute("memberuid"),
             );
             $this->assertEqualsCanonicalizing(
@@ -33,8 +47,8 @@ class WorkerUnityCourseTest extends UnityWebPortalTestCase
                 $pi_group_entry->getAttribute("manageruid"),
             );
         } finally {
-            ensurePIGroupDoesNotExist("pi_cs124_org1_test");
-            ensureUserDoesNotExist("cs124_org1_test");
+            ensurePIGroupDoesNotExist(self::$course_gid);
+            ensureUserDoesNotExist(self::$course_owner_uid);
             unlink($stdin_file_path);
         }
     }

--- a/test/functional/WorkerUnityCourseTest.php
+++ b/test/functional/WorkerUnityCourseTest.php
@@ -11,14 +11,7 @@ class WorkerUnityCourseTest extends UnityWebPortalTestCase
         $owner_user_entry = $LDAP->getUserEntry("cs124_org1_test");
         $this->assertFalse($pi_group_entry->exists());
         $this->assertFalse($owner_user_entry->exists());
-        $admin_uid = self::$NICKNAME2UID["Admin"];
-        $stdin_file = writeLinesToTmpFile([
-            "cs124",
-            "Fall 2025",
-            "cs124_org1_test",
-            $admin_uid,
-            $manager->uid,
-        ]);
+        $stdin_file = writeLinesToTmpFile(["cs124", "Fall 2025", "cs124_org1_test", $manager->uid]);
         $stdin_file_path = getPathFromFileHandle($stdin_file);
         try {
             executeWorker("unity-course.php", stdinFilePath: $stdin_file_path);

--- a/test/phpunit-bootstrap.php
+++ b/test/phpunit-bootstrap.php
@@ -327,7 +327,7 @@ class UnityWebPortalTestCase extends TestCase
                 $this->assertNotEmpty($USER->getPIGroup()->getManagerUIDs());
                 break;
             case "CourseGroupManager":
-                $this->assertNotEmpty($LDAP->getPIGroupGIDSWithManager($USER->uid));
+                $this->assertNotEmpty($LDAP->getNonDisabledPIGroupGIDsWithManagerUID($USER->uid));
                 break;
             case "CustomMapped555":
                 $this->assertFalse($USER->exists());

--- a/test/phpunit-bootstrap.php
+++ b/test/phpunit-bootstrap.php
@@ -276,6 +276,12 @@ class UnityWebPortalTestCase extends TestCase
         "user2003_org998_test" => ["user2003@org1.test", "foo", "bar", "user2001@org1.test"],
         "user2004_org998_test" => ["user2004@org1.test", "foo", "bar", "user2001@org1.test"],
         "user2005_org1_test" => ["user2005@org1.test", "foo", "bar", "user2005@org1.test"],
+        "cs123_org1_test" => [
+            "cs123@org1.test",
+            "cs123",
+            "Fall 2025",
+            "user1+cs123_org1_test@org1.test",
+        ],
     ];
     public static array $NICKNAME2UID = [
         "Admin" => "user1_org1_test",

--- a/test/phpunit-bootstrap.php
+++ b/test/phpunit-bootstrap.php
@@ -266,8 +266,6 @@ class UnityWebPortalTestCase extends TestCase
         "user9_org3_test" => ["user9@org3.test", "foo", "bar", "user9@org3.test"],
         "user10_org1_test" => ["user10@org1.test", "foo", "bar", "user10@org1.test"],
         "user11_org1_test" => ["user11@org1.test", "foo", "bar", "user11@org1.test"],
-        "user12_org1_test" => ["user12@org1.test", "foo", "bar", "user12@org1.test"],
-        "user13_org1_test" => ["user13@org1.test", "foo", "bar", "user13@org1.test"],
         "user2001_org998_test" => ["user2001@org998.test", "foo", "bar", "user2001@org998.test"],
         "user2002_org998_test" => ["user2002@org998.test", "foo", "bar", "user2002@org998.test"],
         "user2003_org998_test" => ["user2003@org1.test", "foo", "bar", "user2001@org1.test"],
@@ -278,7 +276,8 @@ class UnityWebPortalTestCase extends TestCase
         "Admin" => "user1_org1_test",
         "Blank" => "user2_org1_test",
         "EmptyPIGroupOwner" => "user5_org2_test",
-        "CourseWorkerTestManager" => "user12_org1_test",
+        "CourseGroupOwner" => "cs123_org1_test",
+        "CourseGroupManager" => "user1_org1_test",
         "CustomMapped555" => "user2002_org998_test",
         "Disabled" => "user7_org1_test",
         "DisabledNotPI" => "user7_org1_test",
@@ -288,8 +287,6 @@ class UnityWebPortalTestCase extends TestCase
         "HasOneSshKey" => "user5_org2_test",
         "IdleLocked" => "user6_org1_test",
         "Locked" => "user8_org1_test",
-        "ManagedPIGroupOwner" => "user13_org1_test",
-        "Manager" => "user1_org1_test",
         "NonExistent" => "user2001_org998_test",
         "Normal" => "user4_org1_test",
         "NormalPI" => "user11_org1_test",
@@ -321,8 +318,12 @@ class UnityWebPortalTestCase extends TestCase
                 $this->assertTrue($LDAP->getUserGroupEntry($USER->uid)->exists());
                 $this->assertTrue($LDAP->getOrgGroupEntry($USER->getOrg())->exists());
                 break;
-            case "CourseWorkerTestManager":
-                $this->assertEmpty($LDAP->getPIGroupGIDSWithManager($USER->uid));
+            case "CourseGroupOwner":
+                $this->assertTrue($USER->getPIGroup()->exists());
+                $this->assertNotEmpty($USER->getPIGroup()->getManagerUIDs());
+                break;
+            case "CourseGroupManager":
+                $this->assertNotEmpty($LDAP->getPIGroupGIDSWithManager($USER->uid));
                 break;
             case "CustomMapped555":
                 $this->assertFalse($USER->exists());
@@ -365,12 +366,6 @@ class UnityWebPortalTestCase extends TestCase
                 break;
             case "Locked":
                 $this->assertTrue($USER->getFlag(UserFlag::LOCKED));
-                break;
-            case "ManagedPIGroupOwner":
-                $this->assertNotEmpty($USER->getPIGroup()->getManagerUIDs());
-                break;
-            case "Manager":
-                $this->assertNotEmpty($LDAP->getPIGroupGIDSWithManager($USER->uid));
                 break;
             case "NonExistent":
                 $this->assertFalse($USER->exists());

--- a/test/phpunit-bootstrap.php
+++ b/test/phpunit-bootstrap.php
@@ -270,6 +270,7 @@ class UnityWebPortalTestCase extends TestCase
         "user9_org3_test" => ["user9@org3.test", "foo", "bar", "user9@org3.test"],
         "user10_org1_test" => ["user10@org1.test", "foo", "bar", "user10@org1.test"],
         "user11_org1_test" => ["user11@org1.test", "foo", "bar", "user11@org1.test"],
+        "user12_org1_test" => ["user12@org1.test", "foo", "bar", "user12@org1.test"],
         "user2001_org998_test" => ["user2001@org998.test", "foo", "bar", "user2001@org998.test"],
         "user2002_org998_test" => ["user2002@org998.test", "foo", "bar", "user2002@org998.test"],
         "user2003_org998_test" => ["user2003@org1.test", "foo", "bar", "user2001@org1.test"],
@@ -286,6 +287,7 @@ class UnityWebPortalTestCase extends TestCase
         "Disabled" => "user7_org1_test",
         "DisabledNotPI" => "user7_org1_test",
         "DisabledOwnerOfDisabledPIGroup" => "user9_org3_test",
+        "DisabledPIGroup_user9_org3_test_Manager" => "user12_org1_test",
         "ReenabledOwnerOfDisabledPIGroup" => "user10_org1_test",
         "HasNoSshKeys" => "user3_org1_test",
         "HasOneSshKey" => "user5_org2_test",
@@ -352,6 +354,11 @@ class UnityWebPortalTestCase extends TestCase
             case "DisabledNotPI":
                 $this->assertTrue($USER->getFlag(UserFlag::DISABLED));
                 $this->assertFalse($USER->getPIGroup()->exists());
+                break;
+            case "DisabledPIGroup_user9_org3_test_Manager":
+                $pi_group_entry = $LDAP->getPIGroupEntry("user9_org3_test");
+                $this->assertContains($USER->uid, $pi_group_entry->getAttribute("manageruid"));
+                $this->assertEquals("TRUE", $pi_group_entry->getAttribute("isDisabled")[0]);
                 break;
             case "ReenabledOwnerOfDisabledPIGroup":
                 $this->assertTrue($USER->exists());

--- a/test/phpunit-bootstrap.php
+++ b/test/phpunit-bootstrap.php
@@ -266,6 +266,8 @@ class UnityWebPortalTestCase extends TestCase
         "user9_org3_test" => ["user9@org3.test", "foo", "bar", "user9@org3.test"],
         "user10_org1_test" => ["user10@org1.test", "foo", "bar", "user10@org1.test"],
         "user11_org1_test" => ["user11@org1.test", "foo", "bar", "user11@org1.test"],
+        "user12_org1_test" => ["user12@org1.test", "foo", "bar", "user12@org1.test"],
+        "user13_org1_test" => ["user13@org1.test", "foo", "bar", "user13@org1.test"],
         "user2001_org998_test" => ["user2001@org998.test", "foo", "bar", "user2001@org998.test"],
         "user2002_org998_test" => ["user2002@org998.test", "foo", "bar", "user2002@org998.test"],
         "user2003_org998_test" => ["user2003@org1.test", "foo", "bar", "user2001@org1.test"],
@@ -276,6 +278,7 @@ class UnityWebPortalTestCase extends TestCase
         "Admin" => "user1_org1_test",
         "Blank" => "user2_org1_test",
         "EmptyPIGroupOwner" => "user5_org2_test",
+        "CourseWorkerTestManager" => "user12_org1_test",
         "CustomMapped555" => "user2002_org998_test",
         "Disabled" => "user7_org1_test",
         "DisabledNotPI" => "user7_org1_test",
@@ -285,6 +288,8 @@ class UnityWebPortalTestCase extends TestCase
         "HasOneSshKey" => "user5_org2_test",
         "IdleLocked" => "user6_org1_test",
         "Locked" => "user8_org1_test",
+        "ManagedPIGroupOwner" => "user13_org1_test",
+        "Manager" => "user1_org1_test",
         "NonExistent" => "user2001_org998_test",
         "Normal" => "user4_org1_test",
         "NormalPI" => "user11_org1_test",
@@ -315,6 +320,9 @@ class UnityWebPortalTestCase extends TestCase
                 $this->assertTrue($LDAP->getUserEntry($USER->uid)->exists());
                 $this->assertTrue($LDAP->getUserGroupEntry($USER->uid)->exists());
                 $this->assertTrue($LDAP->getOrgGroupEntry($USER->getOrg())->exists());
+                break;
+            case "CourseWorkerTestManager":
+                $this->assertEmpty($LDAP->getPIGroupGIDSWithManager($USER->uid));
                 break;
             case "CustomMapped555":
                 $this->assertFalse($USER->exists());
@@ -357,6 +365,12 @@ class UnityWebPortalTestCase extends TestCase
                 break;
             case "Locked":
                 $this->assertTrue($USER->getFlag(UserFlag::LOCKED));
+                break;
+            case "ManagedPIGroupOwner":
+                $this->assertNotEmpty($USER->getPIGroup()->getManagerUIDs());
+                break;
+            case "Manager":
+                $this->assertNotEmpty($LDAP->getPIGroupGIDSWithManager($USER->uid));
                 break;
             case "NonExistent":
                 $this->assertFalse($USER->exists());

--- a/test/phpunit-bootstrap.php
+++ b/test/phpunit-bootstrap.php
@@ -356,7 +356,7 @@ class UnityWebPortalTestCase extends TestCase
                 $this->assertFalse($USER->getPIGroup()->exists());
                 break;
             case "DisabledPIGroup_user9_org3_test_Manager":
-                $pi_group_entry = $LDAP->getPIGroupEntry("user9_org3_test");
+                $pi_group_entry = $LDAP->getPIGroupEntry("pi_user9_org3_test");
                 $this->assertContains($USER->uid, $pi_group_entry->getAttribute("manageruid"));
                 $this->assertEquals("TRUE", $pi_group_entry->getAttribute("isDisabled")[0]);
                 break;

--- a/test/phpunit-bootstrap.php
+++ b/test/phpunit-bootstrap.php
@@ -197,6 +197,10 @@ function ensureUserDoesNotExist(string $uid)
         if (in_array($uid, $pi_group_members)) {
             $pi_group_entry->removeAttributeEntryByValue("memberuid", $uid);
         }
+        $managers = $pi_group_entry->getAttribute("manageruid");
+        if (in_array($uid, $managers)) {
+            $pi_group_entry->removeAttributeEntryByValue("manageruid", $uid);
+        }
     }
 }
 

--- a/test/phpunit-bootstrap.php
+++ b/test/phpunit-bootstrap.php
@@ -67,8 +67,12 @@ $HTTP_HEADER_TEST_INPUTS = [
     _mb_convert_encoding("Hello, World!", "UTF-16"),
 ];
 
-function http_post(string $phpfile, array $post_data, bool $do_generate_csrf_token = true): string
-{
+function http_post(
+    string $phpfile,
+    array $post_data,
+    array $query_parameters = [],
+    bool $do_generate_csrf_token = true,
+): string {
     global $LDAP, $SQL, $MAILER, $WEBHOOK, $GITHUB, $SITE, $SSO, $USER, $LOC_HEADER, $LOC_FOOTER;
     $_PREVIOUS_SERVER = $_SERVER;
     $_SERVER["REQUEST_METHOD"] = "POST";
@@ -78,6 +82,7 @@ function http_post(string $phpfile, array $post_data, bool $do_generate_csrf_tok
         $post_data["csrf_token"] = CSRFToken::generate();
     }
     $_POST = $post_data;
+    $_GET = $query_parameters;
     ob_start();
     try {
         $post_did_redirect_or_die = false;
@@ -94,6 +99,7 @@ function http_post(string $phpfile, array $post_data, bool $do_generate_csrf_tok
         throw $e;
     } finally {
         unset($_POST);
+        unset($_GET);
         $_SERVER = $_PREVIOUS_SERVER;
     }
 }

--- a/tools/docker-dev/identity/account-portal-schema.ldif
+++ b/tools/docker-dev/identity/account-portal-schema.ldif
@@ -7,7 +7,12 @@ olcAttributeTypes: ( 1.1.1 NAME 'isDisabled'
     SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
     SINGLE-VALUE
     )
+olcAttributeTypes: ( 1.1.3 NAME 'managerUid'
+    DESC 'users with permission to manage group'
+    EQUALITY caseExactIA5Match
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+    )
 olcObjectClasses: ( 1.1.2 NAME 'piGroup' SUP top AUXILIARY
     DESC 'PI Group'
-    MAY ( isDisabled )
+    MAY ( isDisabled $ managerUid )
     )

--- a/tools/docker-dev/identity/bootstrap.ldif
+++ b/tools/docker-dev/identity/bootstrap.ldif
@@ -37349,7 +37349,7 @@ gecos: Melissa Price
 uid: user2005_org1_test
 uidnumber: 33130
 
-dn: cn=cs123_org1_test,ou=groups,dc=unityhpc,dc=test
+dn: cn=cs123_org1_test,ou=user_groups,dc=unityhpc,dc=test
 objectClass: posixGroup
 objectClass: top
 gidNumber: 20005

--- a/tools/docker-dev/identity/bootstrap.ldif
+++ b/tools/docker-dev/identity/bootstrap.ldif
@@ -37364,19 +37364,20 @@ uid: cs123_org1_test
 givenName: cs123
 sn: Fall 2025
 gecos: cs123 Fall 2025
-mail: user12@org1.test
+mail: user1+cs123_org1_test@org1.test
 o: org1_test
 homeDirectory: /home/cs123_org1_test
 loginShell: /bin/bash
 uidNumber: 20005
 gidNumber: 20005
 cn: cs123_org1_test
-managerUid: user12_org1_test
 
 dn: cn=pi_cs123_org1_test,ou=pi_groups,dc=unityhpc,dc=test
+objectclass: unityClusterPIGroup
 objectClass: posixGroup
 objectClass: top
 gidNumber: 20007
 cn: pi_cs123_org1_test
+managerUid: user1_org1_test
 memberUid: cs123_org1_test
-memberUid: user12_org1_test
+memberUid: user1_org1_test

--- a/tools/docker-dev/identity/bootstrap.ldif
+++ b/tools/docker-dev/identity/bootstrap.ldif
@@ -1200,6 +1200,7 @@ memberuid: user1299_org1_test
 memberuid: user1300_org1_test
 memberuid: user1301_org1_test
 memberuid: user1304_org1_test
+memberuid: cs123_org1_test
 
 dn: cn=user15_org3_test,ou=user_groups,dc=unityhpc,dc=test
 cn: user15_org3_test
@@ -13470,6 +13471,7 @@ dn: cn=pi_user13_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user13_org1_test
 gidnumber: 10226
 memberuid: user13_org1_test
+manageruid: user1_org1_test
 objectclass: piGroup
 objectclass: posixGroup
 objectclass: top
@@ -37346,3 +37348,35 @@ sn: Price
 gecos: Melissa Price
 uid: user2005_org1_test
 uidnumber: 33130
+
+dn: cn=cs123_org1_test,ou=groups,dc=unityhpc,dc=test
+objectClass: posixGroup
+objectClass: top
+gidNumber: 20005
+cn: cs123_org1_test
+
+dn: cn=cs123_org1_test,ou=users,dc=unityhpc,dc=test
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: top
+objectClass: ldapPublicKey
+uid: cs123_org1_test
+givenName: cs123
+sn: Fall 2025
+gecos: cs123 Fall 2025
+mail: user12@org1.test
+o: org1_test
+homeDirectory: /home/cs123_org1_test
+loginShell: /bin/bash
+uidNumber: 20005
+gidNumber: 20005
+cn: cs123_org1_test
+managerUid: user12_org1_test
+
+dn: cn=pi_cs123_org1_test,ou=pi_groups,dc=unityhpc,dc=test
+objectClass: posixGroup
+objectClass: top
+gidNumber: 20007
+cn: pi_cs123_org1_test
+memberUid: cs123_org1_test
+memberUid: user12_org1_test

--- a/tools/docker-dev/identity/bootstrap.ldif
+++ b/tools/docker-dev/identity/bootstrap.ldif
@@ -37373,7 +37373,7 @@ gidNumber: 20005
 cn: cs123_org1_test
 
 dn: cn=pi_cs123_org1_test,ou=pi_groups,dc=unityhpc,dc=test
-objectclass: unityClusterPIGroup
+objectclass: piGroup
 objectClass: posixGroup
 objectClass: top
 gidNumber: 20007

--- a/tools/docker-dev/identity/bootstrap.ldif
+++ b/tools/docker-dev/identity/bootstrap.ldif
@@ -10960,6 +10960,7 @@ objectclass: piGroup
 objectclass: posixGroup
 objectclass: top
 isDisabled: TRUE
+managerUid: user12_org1_test
 
 dn: cn=pi_user10_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user10_org1_test

--- a/tools/docker-dev/identity/bootstrap.ldif
+++ b/tools/docker-dev/identity/bootstrap.ldif
@@ -10960,7 +10960,7 @@ objectclass: piGroup
 objectclass: posixGroup
 objectclass: top
 isDisabled: TRUE
-managerUid: user12_org1_test
+manageruid: user12_org1_test
 
 dn: cn=pi_user10_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user10_org1_test
@@ -37378,6 +37378,6 @@ objectClass: posixGroup
 objectClass: top
 gidNumber: 20007
 cn: pi_cs123_org1_test
-managerUid: user1_org1_test
-memberUid: cs123_org1_test
-memberUid: user1_org1_test
+manageruid: user1_org1_test
+memberuid: cs123_org1_test
+memberuid: user1_org1_test

--- a/tools/docker-dev/identity/bootstrap.ldif
+++ b/tools/docker-dev/identity/bootstrap.ldif
@@ -13471,7 +13471,6 @@ dn: cn=pi_user13_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user13_org1_test
 gidnumber: 10226
 memberuid: user13_org1_test
-manageruid: user1_org1_test
 objectclass: piGroup
 objectclass: posixGroup
 objectclass: top

--- a/webroot/panel/pi.php
+++ b/webroot/panel/pi.php
@@ -24,6 +24,10 @@ if (($gid = $_GET["gid"] ?? null) !== null) {
     }
 }
 
+if ($group->getIsDisabled()) {
+    UnityHTTPD::forbidden("group '$gid' is disabled", "This group is disabled.");
+}
+
 $getUserFromPost = function () {
     global $LDAP, $SQL, $MAILER, $WEBHOOK;
     return new UnityUser(UnityHTTPD::getPostData("uid"), $LDAP, $SQL, $MAILER, $WEBHOOK);

--- a/webroot/panel/pi.php
+++ b/webroot/panel/pi.php
@@ -138,10 +138,6 @@ echo "
 
 $owner_uid = $group->getOwner()->uid;
 foreach ($assocs as $assoc) {
-    if ($assoc->uid == $USER->uid) {
-        continue;
-    }
-
     echo "<tr>";
     echo "<td>" . $assoc->getFirstname() . " " . $assoc->getLastname() . "</td>";
     echo "<td>" . $assoc->uid . "</td>";

--- a/webroot/panel/pi.php
+++ b/webroot/panel/pi.php
@@ -13,7 +13,7 @@ if (($gid = $_GET["gid"] ?? null) !== null) {
     }
     if (!in_array($USER->uid, $group->getManagerUIDs())) {
         UnityHTTPD::forbidden(
-            "user '$USER->uid' is a manager of group '$gid'",
+            "user '$USER->uid' is not a manager of group '$gid'",
             "You are not allowed to manage this PI group."
         );
     }

--- a/webroot/panel/pi.php
+++ b/webroot/panel/pi.php
@@ -136,6 +136,7 @@ echo "
         <tbody>
 ";
 
+$owner_uid = $group->getOwner()->uid;
 foreach ($assocs as $assoc) {
     if ($assoc->uid == $USER->uid) {
         continue;

--- a/webroot/panel/pi.php
+++ b/webroot/panel/pi.php
@@ -47,7 +47,10 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             $form_user = $getUserFromPost();
             // remove user button clicked
             $group->removeUser($form_user);
-
+            // group manager removed themself
+            if ($USER->uid === $form_user->uid) {
+                UnityHTTPD::redirect("/panel/groups.php");
+            }
             break;
         case "disable":
             if (!$user_is_owner) {

--- a/webroot/panel/pi.php
+++ b/webroot/panel/pi.php
@@ -89,8 +89,6 @@ if ($user_is_owner) {
     echo sprintf("<h1>PI Group '$group->gid'</h1>");
 }
 ?>
-
-<h1>PI Group Management</h1>
 <hr>
 
 <?php

--- a/webroot/panel/pi.php
+++ b/webroot/panel/pi.php
@@ -135,9 +135,8 @@ echo "
         <tbody>
 ";
 
-$owner_uid = $group->getOwner()->uid;
 foreach ($assocs as $assoc) {
-    if ($assoc->uid == $owner_uid) {
+    if ($assoc->uid == $USER->uid) {
         continue;
     }
 

--- a/webroot/panel/pi.php
+++ b/webroot/panel/pi.php
@@ -39,19 +39,28 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             $form_user = $getUserFromPost();
             if ($_POST["action"] == "Approve") {
                 $group->approveUser($form_user);
+                UnityHTTPD::messageSuccess("User Approved", "");
+                UnityHTTPD::redirect();
             } elseif ($_POST["action"] == "Deny") {
                 $group->denyUser($form_user);
+                UnityHTTPD::messageSuccess("User Denied", "");
+                UnityHTTPD::redirect();
+            } else {
+                UnityHTTPD::badRequest(sprintf("unrecognized action: '%s'", $_POST["action"]), "");
             }
-            break;
+            break; /** @phpstan-ignore deadCode.unreachable */
         case "remUser":
             $form_user = $getUserFromPost();
             // remove user button clicked
             $group->removeUser($form_user);
+            UnityHTTPD::messageSuccess("User Removed", "");
             // group manager removed themself
             if ($USER->uid === $form_user->uid) {
                 UnityHTTPD::redirect("/panel/groups.php");
+            } else {
+                UnityHTTPD::redirect();
             }
-            break;
+            break; /** @phpstan-ignore deadCode.unreachable */
         case "disable":
             if (!$user_is_owner) {
                 UnityHTTPD::forbidden("Manager cannot disable", "Only the group owner can disable");

--- a/webroot/panel/pi.php
+++ b/webroot/panel/pi.php
@@ -67,7 +67,7 @@ require getTemplatePath("header.php");
 $CSRFTokenHiddenFormInput = UnityHTTPD::getCSRFTokenHiddenFormInput();
 ?>
 
-<h1>My Users</h1>
+<h1>PI Group Management</h1>
 <hr>
 
 <?php

--- a/webroot/panel/pi.php
+++ b/webroot/panel/pi.php
@@ -12,15 +12,12 @@ if (($gid = $_GET["gid"] ?? null) !== null) {
         UnityHTTPD::badRequest("no such group: '$gid'", "This group does not exist.");
     }
     if (!in_array($USER->uid, $group->getManagerUIDs())) {
-        UnityHTTPD::forbidden(
-            "user '$USER->uid' is not a manager of group '$gid'",
-            "You are not allowed to manage this PI group."
-        );
+        UnityHTTPD::forbidden("not a manager of group '$gid'", "You cannot manage this group.");
     }
 } else {
     $group = $USER->getPIGroup();
-    if (!$USER->isPI()) {
-        UnityHTTPD::forbidden("not a PI", "You are not a PI.");
+    if (!$group->exists()) {
+        UnityHTTPD::badRequest("not a PI", "You are not a PI.");
     }
 }
 

--- a/webroot/panel/pi.php
+++ b/webroot/panel/pi.php
@@ -82,6 +82,12 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 
 require getTemplatePath("header.php");
 $CSRFTokenHiddenFormInput = UnityHTTPD::getCSRFTokenHiddenFormInput();
+
+if ($user_is_owner) {
+    echo "<h1>My Users</h1>";
+} else {
+    echo sprintf("<h1>PI Group '$group->gid'</h1>");
+}
 ?>
 
 <h1>PI Group Management</h1>

--- a/workers/unity-course.php
+++ b/workers/unity-course.php
@@ -13,6 +13,12 @@ function cn2org($cn)
     return $matches[1];
 }
 
+function insert_plus_address($email, $plus)
+{
+    $parts = explode("@", $email, 2);
+    return $parts[0] . "+" . $plus . "@" . $parts[1];
+}
+
 // if array is length 1 then replace it with its one element
 function flatten_attributes(array $attributes): array
 {
@@ -43,7 +49,8 @@ $org = new UnityOrg($org_gid, $LDAP);
 if (!$org->exists()) {
     print "WARNING: creating new org '$org_gid'...\n";
 }
-$course_user->init($givenName, $sn, $manager->getMail(), $org_gid);
+$mail = insert_plus_address($manager->getMail(), $cn);
+$course_user->init($givenName, $sn, $mail, $org_gid);
 
 $course_pi_group = $course_user->getPIGroup();
 if ($course_pi_group->exists()) {


### PR DESCRIPTION
Previous attempts: https://github.com/UnityHPC/account-portal/pull/534 https://github.com/UnityHPC/account-portal/pull/564

Adds a new attribute to each PI group `managerUid`. in `groups.php`, if the current user is in the list of manager UIDs, there will be a button to "Manage Group", which redirects to `pi.php?gid=...`.

`pi.php` now accepts a query parameter to manage another group, with authorization using `managerUid`.

<img width="720" height="288" alt="image" src="https://github.com/user-attachments/assets/b1c9a45b-9c3e-4877-8461-67a1daaf8c9e" />

The `unity-course.php` worker is updated to remove all involvement from an admin, and instead add a manager.

A group manager cannot disband the group. If a group manager removes themself from the group, they automatically lose manager status, and are redirected to the page `groups.php` so that they don't get a permission denied error.

I also added messages for the POST actions in `pi.php`.