### PR TITLE
json throw on error

### DIFF
--- a/resources/lib/utils.php
+++ b/resources/lib/utils.php
@@ -85,6 +85,7 @@ function _json_encode(mixed $value, int $flags = 0, int $depth = 512): string
 
 /**
  * @param int<1,max> $depth
+ * @throws \JsonException
  */
 function _json_decode(string $x, ?bool $associative = null, int $depth = 512, int $flags = 0): mixed
 {


### PR DESCRIPTION
Enables the `JSON_THROW_ON_ERROR` flag for `_json_decode`, just like it is for `_json_encode`. Removes the check for a `null` return value of `json_decode`, because `null` is a valid return value.

`_json_encode` still has a check for a `false` return value, because phpstan complains without it. `false` should never be returned when `JSON_THROW_ON_ERROR`. I could use `assert` instead of a conditional, but the code conventions say to always use `ensure` instead of `assert`, and phpstan doesn't understand `ensure`.