### PR TITLE
fix key download on safari

### DIFF
--- a/webroot/panel/modal/new_key.php
+++ b/webroot/panel/modal/new_key.php
@@ -107,11 +107,10 @@ $CSRFTokenHiddenFormInput = UnityHTTPD::getCSRFTokenHiddenFormInput();
         }, 300);
     });
 
-    $("#key_paste > textarea").on("input", function() {
+    $("textarea[name=key]").on("input", function() {
         var key = $(this).val();
-        var submit = $(this).siblings("input[type=submit]")
         if (key == "") {
-            submit.prop("disabled", true);
+            $("input[id=add-key]").prop("disabled", true);
             $("#key_invalid_explanation").text("");
             return;
         }


### PR DESCRIPTION
Safari makes a popup asking if you want to allow downloads on this site. Since the JS submits the form and reloads the page immediately after initiating the download, the user never sees the popup and the download is declined.

To work around this, I separated the download and the upload into two separate buttons, and added a note that the user now needs to press a second button.

demo of it working now:

https://github.com/user-attachments/assets/bc2109b2-4d36-4fae-a1e9-1ab5f0832641