### PR TITLE
Error message styling

### DIFF
--- a/resources/lib/UnityHTTPD.php
+++ b/resources/lib/UnityHTTPD.php
@@ -70,7 +70,7 @@ class UnityHTTPD
         $errorid = uniqid();
         $title = htmlspecialchars($user_message_title);
         if (trim($user_message_body) !== "") {
-            $body_lines = explode("\n", $user_message_body);
+            $body_lines = explode("\n", htmlspecialchars($user_message_body));
         } else {
             $body_lines = [];
         }

--- a/resources/lib/UnityHTTPD.php
+++ b/resources/lib/UnityHTTPD.php
@@ -52,7 +52,7 @@ class UnityHTTPD
 
     /*
     generates a unique error ID, writes to error log, and then:
-        if the user is doing an HTTP POST and the current page is not an API endpoint:
+        if the user is doing an HTTP POST:
             registers a message in the user's session and issues a redirect to display that message
         else:
             prints an HTML message to stdout, sets an HTTP response code, and dies

--- a/resources/lib/UnityHTTPD.php
+++ b/resources/lib/UnityHTTPD.php
@@ -69,14 +69,17 @@ class UnityHTTPD
     ): never {
         $errorid = uniqid();
         $title = htmlspecialchars($user_message_title);
-        $body_lines = [
-            htmlspecialchars($user_message_body),
-            "For assistance, contact a Unity admin at " . CONFIG["mail"]["support"],
-            "Error ID: $errorid",
-        ];
+        if (trim($user_message_body) !== "") {
+            $body_lines = explode($user_message_body, "\n");
+        } else {
+            $body_lines = [];
+        }
+        $support = CONFIG["mail"]["support"];
+        array_push($body_lines, "For assistance, contact a Unity admin at $support.");
+        array_push($body_lines, "Error ID: $errorid");
         self::errorLog($log_title, $log_message, data: $data, error: $error, errorid: $errorid);
         if (($_SERVER["REQUEST_METHOD"] ?? "") == "POST") {
-            self::messageError($title, implode("\n", $body_lines));
+            self::messageError($title, trim(implode("\n", $body_lines)));
             self::redirect();
         } else {
             if (!headers_sent()) {

--- a/resources/lib/UnityHTTPD.php
+++ b/resources/lib/UnityHTTPD.php
@@ -70,7 +70,7 @@ class UnityHTTPD
         $errorid = uniqid();
         $title = htmlspecialchars($user_message_title);
         if (trim($user_message_body) !== "") {
-            $body_lines = explode("\n", $user_message_body);
+            $body_lines = explode("\n", trim($user_message_body));
         } else {
             $body_lines = [];
         }

--- a/resources/lib/UnityHTTPD.php
+++ b/resources/lib/UnityHTTPD.php
@@ -87,7 +87,7 @@ class UnityHTTPD
             }
             // text may not be shown in the webpage in an obvious way, so make a popup
             self::alert(implode(" -- ", [$title, ...$body_lines]));
-            echo sprintf("<h1>%s</h1><p>%s</p>", $title, implode("<br>", $body_lines));
+            echo sprintf("<h1>%s</h1>\n<p>\n%s\n</p>\n", $title, implode("<br>\n", $body_lines));
             // display_errors should not be enabled in production
             if (
                 !is_null($error) &&
@@ -285,8 +285,10 @@ class UnityHTTPD
     // after I disable alerts, if I quit and reopen my browser, the alerts come back
     public static function alert(string $message): void
     {
-        // jsonEncode escapes quotes
-        echo "<script type='text/javascript'>alert(" . \_json_encode($message) . ");</script>";
+        echo sprintf(
+            "<script type='text/javascript'>\nalert('%s');\n</script>\n",
+            htmlspecialchars($message),
+        );
     }
 
     private static function ensureSessionMessagesSanity(): void

--- a/resources/lib/UnityHTTPD.php
+++ b/resources/lib/UnityHTTPD.php
@@ -70,7 +70,7 @@ class UnityHTTPD
         $errorid = uniqid();
         $title = htmlspecialchars($user_message_title);
         if (trim($user_message_body) !== "") {
-            $body_lines = explode($user_message_body, "\n");
+            $body_lines = explode("\n", $user_message_body);
         } else {
             $body_lines = [];
         }

--- a/resources/lib/UnityHTTPD.php
+++ b/resources/lib/UnityHTTPD.php
@@ -70,7 +70,7 @@ class UnityHTTPD
         $errorid = uniqid();
         $title = htmlspecialchars($user_message_title);
         if (trim($user_message_body) !== "") {
-            $body_lines = explode("\n", htmlspecialchars($user_message_body));
+            $body_lines = explode("\n", $user_message_body);
         } else {
             $body_lines = [];
         }
@@ -79,7 +79,7 @@ class UnityHTTPD
         array_push($body_lines, "Error ID: $errorid");
         self::errorLog($log_title, $log_message, data: $data, error: $error, errorid: $errorid);
         if (($_SERVER["REQUEST_METHOD"] ?? "") == "POST") {
-            self::messageError($title, trim(implode("\n", $body_lines)));
+            self::messageError($title, implode("\n", $body_lines));
             self::redirect();
         } else {
             if (!headers_sent()) {
@@ -87,7 +87,11 @@ class UnityHTTPD
             }
             // text may not be shown in the webpage in an obvious way, so make a popup
             self::alert(implode(" -- ", [$title, ...$body_lines]));
-            echo sprintf("<h1>%s</h1>\n<p>\n%s\n</p>\n", $title, implode("<br>\n", $body_lines));
+            echo sprintf(
+                "<h1>%s</h1>\n<p>\n%s\n</p>\n",
+                $title,
+                nl2br(htmlspecialchars(implode("\n", $body_lines))),
+            );
             // display_errors should not be enabled in production
             if (
                 !is_null($error) &&

--- a/resources/lib/UnityHTTPD.php
+++ b/resources/lib/UnityHTTPD.php
@@ -52,7 +52,7 @@ class UnityHTTPD
 
     /*
     generates a unique error ID, writes to error log, and then:
-        if the user is doing an HTTP POST:
+        if the user is doing an HTTP POST and the current page is not an API endpoint:
             registers a message in the user's session and issues a redirect to display that message
         else:
             prints an HTML message to stdout, sets an HTTP response code, and dies

--- a/resources/lib/UnityHTTPD.php
+++ b/resources/lib/UnityHTTPD.php
@@ -68,29 +68,23 @@ class UnityHTTPD
         mixed $data = null,
     ): never {
         $errorid = uniqid();
-        $suffix = sprintf(
-            "For assistance, contact a Unity admin at %s. Error ID: %s.",
-            CONFIG["mail"]["support"],
-            $errorid,
-        );
-        $user_message_title = htmlspecialchars($user_message_title);
-        $user_message_body = htmlspecialchars($user_message_body);
-        if (strlen($user_message_body) === 0) {
-            $user_message_body = $suffix;
-        } else {
-            $user_message_body .= " $suffix";
-        }
+        $title = htmlspecialchars($user_message_title);
+        $body_lines = [
+            htmlspecialchars($user_message_body),
+            "For assistance, contact a Unity admin at " . CONFIG["mail"]["support"],
+            "Error ID: $errorid",
+        ];
         self::errorLog($log_title, $log_message, data: $data, error: $error, errorid: $errorid);
         if (($_SERVER["REQUEST_METHOD"] ?? "") == "POST") {
-            self::messageError($user_message_title, $user_message_body);
+            self::messageError($title, implode("\n", $body_lines));
             self::redirect();
         } else {
             if (!headers_sent()) {
                 http_response_code($http_response_code);
             }
             // text may not be shown in the webpage in an obvious way, so make a popup
-            self::alert("$user_message_title -- $user_message_body");
-            echo "<h1>$user_message_title</h1><p>$user_message_body</p>";
+            self::alert(implode(" -- ", [$title, ...$body_lines]));
+            echo sprintf("<h1>%s</h1><p>%s</p>", $title, implode("<br>", $body_lines));
             // display_errors should not be enabled in production
             if (
                 !is_null($error) &&

--- a/resources/lib/UnityHTTPD.php
+++ b/resources/lib/UnityHTTPD.php
@@ -68,7 +68,7 @@ class UnityHTTPD
         mixed $data = null,
     ): never {
         $errorid = uniqid();
-        $title = htmlspecialchars($user_message_title);
+        $title = trim($user_message_title);
         if (trim($user_message_body) !== "") {
             $body_lines = explode("\n", trim($user_message_body));
         } else {
@@ -89,7 +89,7 @@ class UnityHTTPD
             self::alert(implode(" -- ", [$title, ...$body_lines]));
             echo sprintf(
                 "<h1>%s</h1>\n<p>\n%s\n</p>\n",
-                $title,
+                nl2br(htmlspecialchars($title)),
                 nl2br(htmlspecialchars(implode("\n", $body_lines))),
             );
             // display_errors should not be enabled in production

--- a/webroot/css/messages.css
+++ b/webroot/css/messages.css
@@ -24,6 +24,10 @@
     margin: 0;
 }
 
+.message p {
+    white-space: pre-line;
+}
+
 .message.debug {
     color: #856404;
     background-color: #fff3cd;

--- a/webroot/css/messages.css
+++ b/webroot/css/messages.css
@@ -22,6 +22,7 @@
 
 .message h3 {
     margin: 0;
+    white-space: pre-line;
 }
 
 .message p {


### PR DESCRIPTION
before:

<img width="1059" height="401" alt="image" src="https://github.com/user-attachments/assets/11b23e14-e00c-4aa4-ac1c-db51bae67795" />

after:

<img width="1077" height="463" alt="image" src="https://github.com/user-attachments/assets/2b241ee4-73c2-4c35-9b53-2941de2a7cd9" />

before:
```html
<script type='text/javascript'>
alert("Invalid requested action or submitted data. -- invalid HTTP_AUTHORIZATION For assistance, contact a Unity admin at support-email@unitywebportal.test. Error ID: 69aacefd0e2f7.");
</script>
<h1>Invalid requested action or submitted data.</h1>
<p>invalid HTTP_AUTHORIZATION For assistance, contact a Unity admin at support-email@unitywebportal.test. Error ID: 69aacefd0e2f7.</p>
```

after:
```html
<script type='text/javascript'>
alert("Invalid requested action or submitted data. -- invalid HTTP_AUTHORIZATION -- For assistance, contact a Unity admin at support-email@unitywebportal.test -- Error ID: 69aad22600c71");
</script>
<h1>Invalid requested action or submitted data.</h1>
<p>
invalid HTTP_AUTHORIZATION
<br>
For assistance, contact a Unity admin at support-email@unitywebportal.test
<br>
Error ID: 69aad22600c71
</p>
```

before:

<img width="436" height="339" alt="image" src="https://github.com/user-attachments/assets/12016edb-e35a-41fb-8a21-483a533775ed" />

after:

<img width="420" height="337" alt="image" src="https://github.com/user-attachments/assets/f7d62028-87e5-4451-85c2-07ea8ece22d4" />

before:

<img width="408" height="175" alt="image" src="https://github.com/user-attachments/assets/f3d74f12-2dc8-41d0-816c-60295b25a163" />

after:

<img width="553" height="165" alt="image" src="https://github.com/user-attachments/assets/19e80c70-3dc2-49ab-95c0-423c52d54bc0" />
