### PR TITLE
why was a user disabled, why was a user removed from group

### DIFF
--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -5,6 +5,13 @@ namespace UnityWebPortal\lib;
 use Exception;
 use UnityWebPortal\lib\exceptions\EntryNotFoundException;
 
+enum UnityGroupUserRemovedReason: string
+{
+    case RemovedByAdmin = "RemovedByAdmin";
+    case RemovedByOwner = "RemovedByOwner";
+    case RemovedSelf = "RemovedSelf";
+}
+
 /**
  * Class that represents a single PI group in the Unity HPC Platform.
  */
@@ -235,8 +242,11 @@ class UnityGroup extends PosixGroup
         }
     }
 
-    public function removeUser(UnityUser $new_user, bool $send_mail = true): void
-    {
+    public function removeUser(
+        UnityUser $new_user,
+        UnityGroupUserRemovedReason|UnityUserDisabledReason $why,
+        bool $send_mail = true,
+    ): void {
         if (!$this->memberUIDExists($new_user->uid)) {
             return;
         }
@@ -251,6 +261,7 @@ class UnityGroup extends PosixGroup
         if ($send_mail) {
             $this->MAILER->sendMail($new_user->getMail(), "group_user_removed", [
                 "group" => $this->gid,
+                "why" => $why,
             ]);
             $this->MAILER->sendMail(
                 $this->getOwnerMailAndPlusAddressedManagerMails(),
@@ -261,6 +272,7 @@ class UnityGroup extends PosixGroup
                     "name" => $new_user->getFullName(),
                     "email" => $new_user->getMail(),
                     "org" => $new_user->getOrg(),
+                    "why" => $why,
                 ],
             );
         }

--- a/resources/lib/UnityUser.php
+++ b/resources/lib/UnityUser.php
@@ -6,6 +6,12 @@ use PHPOpenLDAPer\LDAPEntry;
 use Exception;
 use UnityWebPortal\lib\exceptions\ArrayKeyException;
 
+enum UnityUserDisabledReason: string
+{
+    case DisabledSelf = "DisabledSelf";
+    case Expired = "Expired";
+}
+
 class UnityUser
 {
     private const HOME_DIR = "/home/";
@@ -90,6 +96,7 @@ class UnityUser
         bool $newValue,
         bool $doSendMail = true,
         bool $doSendMailAdmin = true,
+        mixed $why = null,
     ): void {
         $oldValue = $this->getFlag($flag);
         if ($oldValue == $newValue) {
@@ -105,12 +112,14 @@ class UnityUser
                 $this->MAILER->sendMail($this->getMail(), "user_flag_added", [
                     "user" => $this->uid,
                     "flag" => $flag,
+                    "why" => $why,
                 ]);
             }
             if ($doSendMailAdmin) {
                 $this->MAILER->sendMail("admin", "user_flag_added_admin", [
                     "user" => $this->uid,
                     "flag" => $flag,
+                    "why" => $why,
                 ]);
             }
         } else {
@@ -119,12 +128,14 @@ class UnityUser
                 $this->MAILER->sendMail($this->getMail(), "user_flag_removed", [
                     "user" => $this->uid,
                     "flag" => $flag,
+                    "why" => $why,
                 ]);
             }
             if ($doSendMailAdmin) {
                 $this->MAILER->sendMail("admin", "user_flag_removed_admin", [
                     "user" => $this->uid,
                     "flag" => $flag,
+                    "why" => $why,
                 ]);
             }
         }
@@ -384,6 +395,7 @@ class UnityUser
     }
 
     public function disable(
+        UnityUserDisabledReason $why,
         bool $send_mail = true,
         bool $send_mail_pi_group_owner = true,
         bool $send_mail_admin = true,
@@ -394,7 +406,7 @@ class UnityUser
         }
         foreach ($this->LDAP->getNonDisabledPIGroupGIDsWithMemberUID($this->uid) as $gid) {
             $group = new UnityGroup($gid, $this->LDAP, $this->SQL, $this->MAILER);
-            $group->removeUser($this, $send_mail_pi_group_owner);
+            $group->removeUser($this, $why, send_mail: $send_mail_pi_group_owner);
         }
         $this->entry->removeAttribute("sshPublicKey");
         $this->setFlag(
@@ -402,6 +414,7 @@ class UnityUser
             true,
             doSendMail: $send_mail,
             doSendMailAdmin: $send_mail_admin,
+            why: $why,
         );
     }
 

--- a/resources/mail/group_user_removed.html.twig
+++ b/resources/mail/group_user_removed.html.twig
@@ -1,8 +1,26 @@
 {% do setSubject('Removed from Group') %}
+{% set policy_hyperlink = formatHyperlink('account policy', CONFIG['site']['account_expiration_policy_url']) %}
 
 <p>Hello,</p>
 
 <p>You have been removed from the PI group {{ group }}.</p>
+
+{% if why == constant('UnityWebPortal\\lib\\UnityGroupUserRemovedReason::RemovedSelf') %}
+<!-- the user just did this, they don't need to hear "you just did this" -->
+{% elseif why == constant('UnityWebPortal\\lib\\UnityGroupUserRemovedReason::RemovedByAdmin') %}
+<p>You were removed by a Unity administrator.</p>
+{% elseif why == constant('UnityWebPortal\\lib\\UnityGroupUserRemovedReason::RemovedByOwner') %}
+<p>You were removed by the group owner.</p>
+{% elseif why == constant('UnityWebPortal\\lib\\UnityUserDisabledReason::Expired') %}
+<p>
+    You were removed automatically because your account was disabled due to a lapse in credential verification.
+    See the {{ policy_hyperlink|raw }} for more information.
+</p>
+{# this can't happen: a user can't disable their account while they are a member of any group #}
+{# {% elseif why == constant('UnityWebPortal\\lib\\UnityUserDisabledReason::DisabledSelf') %} #}
+{% else %}
+{% do errorLog('warning', 'unexpected removed-from-group reason', data: why) %}
+{% endif %}
 
 <p>If you believe this to be a mistake, please reply to this email as soon as possible.</p>
 {{ include('footer.html.twig') }}

--- a/resources/mail/group_user_removed_owner.html.twig
+++ b/resources/mail/group_user_removed_owner.html.twig
@@ -1,12 +1,31 @@
 {% do setSubject('Group Member Removed') %}
+{% set policy_hyperlink = formatHyperlink('account policy', CONFIG['site']['account_expiration_policy_url']) %}
 
 <p>Hello,</p>
 
 <p>
 A user has been removed from your PI group,
 '{{ group }}'.
-The details of the removed user are below:
 </p>
+
+{% if why == constant('UnityWebPortal\\lib\\UnityGroupUserRemovedReason::RemovedSelf') %}
+<p>The user removed themself from your group.</p>
+{% elseif why == constant('UnityWebPortal\\lib\\UnityGroupUserRemovedReason::RemovedByAdmin') %}
+<p>The user was removed by a Unity admin.</p>
+{% elseif why == constant('UnityWebPortal\\lib\\UnityGroupUserRemovedReason::RemovedByOwner') %}
+<!-- the owner just did this, they don't need to hear "you just did this" -->
+{% elseif why == constant('UnityWebPortal\\lib\\UnityUserDisabledReason::Expired') %}
+<p>
+    The user was removed automatically because their account was disabled due to a lapse in credential verification.
+    See the {{ policy_hyperlink|raw }} for more information.
+</p>
+{# this can't happen: a user can't disable their account while they are a member of any group #}
+{# {% elseif why == constant('UnityWebPortal\\lib\\UnityUserDisabledReason::DisabledSelf') %} #}
+{% else %}
+{% do errorLog('warning', 'unexpected removed-from-group reason', data: why) %}
+{% endif %}
+
+<p>The details of the removed user are below:</p>
 
 <p>
 <strong>Username</strong> {{ user }}

--- a/resources/mail/user_flag_added.html.twig
+++ b/resources/mail/user_flag_added.html.twig
@@ -22,8 +22,17 @@
 <p>
     Your account on the Unity HPC Platform, "{{ user }}", has been disabled.
     You should no longer be able to access Unity HPC Platform services.
-    This can happen as a result of the {{ policy_hyperlink|raw }}.
 </p>
+{% if why == constant('UnityWebPortal\\lib\\UnityUserDisabledReason::DisabledSelf') %}
+<!-- the user just did this, they don't need to hear "you just did this" -->
+{% elseif why == constant('UnityWebPortal\\lib\\UnityUserDisabledReason::Expired') %}
+<p>
+    Your account was expired due to a lapse in credential verification.
+    See the {{ policy_hyperlink|raw }} for more information.
+</p>
+{% else %}
+{% do errorLog('warning', 'unexpected disabled reason', data: why) %}
+{% endif %}
 <p>If you believe this to be a mistake, please reply to this email as soon as possible.</p>
 
 {% elseif flag == constant('UnityWebPortal\\lib\\UserFlag::LOCKED') %}

--- a/resources/mail/user_flag_added_admin.html.twig
+++ b/resources/mail/user_flag_added_admin.html.twig
@@ -8,6 +8,13 @@
 {% do setSubject('User Disabled') %}
 <p>Hello,</p>
 <p>User "{{ user }}" has been disabled. </p>
+{% if why == constant('UnityWebPortal\\lib\\UnityUserDisabledReason::DisabledSelf') %}
+<p>The user disabled themself.</p>
+{% elseif why == constant('UnityWebPortal\\lib\\UnityUserDisabledReason::Expired') %}
+<p>The user expired.</p>
+{% else %}
+{% do errorLog('warning', 'unexpected disabled reason', data: why) %}
+{% endif %}
 
 {% elseif flag == constant('UnityWebPortal\\lib\\UserFlag::LOCKED') %}
 {% do setSubject('User Locked') %}

--- a/test/functional/ExpiryGuiTest.php
+++ b/test/functional/ExpiryGuiTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use UnityWebPortal\lib\UnityUserDisabledReason;
 use UnityWebPortal\lib\UserFlag;
 use UnityWebPortal\lib\UnityHTTPD;
 use UnityWebPortal\lib\UnityHTTPDMessageLevel;
@@ -122,7 +123,7 @@ class ExpiryGuiTest extends UnityWebPortalTestCase
             callPrivateMethod($SQL, "setUserLastLogin", $USER->uid, strtotime("-8 days"));
             $this->assertIdleDays(8);
             $USER->setFlag(UserFlag::IDLELOCKED, true);
-            $USER->disable();
+            $USER->disable(UnityUserDisabledReason::DisabledSelf);
             session_write_close();
             $this->http_get(__DIR__ . "/../../resources/init.php");
             $this->assertNumberOfMessages(0);

--- a/test/functional/ExpiryWorkerTest.php
+++ b/test/functional/ExpiryWorkerTest.php
@@ -309,25 +309,7 @@ class ExpiryWorkerTest extends UnityWebPortalTestCase
             $disable_day = CONFIG["expiry"]["disable_day"];
             $this->assertEquals(8, $disable_day);
             $output = $this->runExpiryWorker(idle_days: 8);
-            $this->assertEquals(
-                sprintf(
-                    "disabling user '%s'\nsending %s email to %s with data %s",
-                    $member->uid,
-                    "group_user_disabled_owner",
-                    _json_encode([
-                        $pi_group->addPlusAddressToMail($manager->getMail()),
-                        $owner->getMail(),
-                    ]),
-                    _json_encode([
-                        "group" => $pi_group->gid,
-                        "user" => $member->uid,
-                        "org" => $member->getOrg(),
-                        "name" => $member->getFullname(),
-                        "email" => $member->getMail(),
-                    ]),
-                ),
-                $output,
-            );
+            $this->assertEquals("disabling user '$member->uid'", $output);
         } finally {
             if ($pi_group->memberUIDExists($member->uid)) {
                 $pi_group->removeMemberUID($member->uid);

--- a/test/functional/ReEnableUserTest.php
+++ b/test/functional/ReEnableUserTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use UnityWebPortal\lib\UnityUserDisabledReason;
 use UnityWebPortal\lib\UnityHTTPDMessageLevel;
 use UnityWebPortal\lib\UserFlag;
 
@@ -22,7 +23,7 @@ class ReEnableUserTest extends UnityWebPortalTestCase
             $this->assertMessageExists(UnityHTTPDMessageLevel::SUCCESS, "/Re-Enabled/", "/.*/");
             $this->assertFalse($USER->getFlag(UserFlag::DISABLED));
         } finally {
-            $USER->setFlag(UserFlag::DISABLED, true);
+            $USER->disable(UnityUserDisabledReason::DisabledSelf);
         }
     }
 
@@ -38,7 +39,7 @@ class ReEnableUserTest extends UnityWebPortalTestCase
             $this->assertFalse($USER->getFlag(UserFlag::DISABLED));
             $this->assertFalse($USER->isPI());
         } finally {
-            $USER->setFlag(UserFlag::DISABLED, true);
+            $USER->disable(UnityUserDisabledReason::DisabledSelf);
         }
     }
 }

--- a/test/functional/WorkerRemoveUsersFromGroupTest.php
+++ b/test/functional/WorkerRemoveUsersFromGroupTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use UnityWebPortal\lib\UnityGroupUserRemovedReason;
 use UnityWebPortal\lib\UnityUser;
 
 class WorkerRemoveUsersFromGroupTest extends UnityWebPortalTestCase
@@ -38,7 +39,7 @@ class WorkerRemoveUsersFromGroupTest extends UnityWebPortalTestCase
         } finally {
             foreach ($uids as $uid) {
                 $user = new UnityUser($uid, $LDAP, $SQL, $MAILER);
-                $pi_group->removeUser($user);
+                $pi_group->removeUser($user, UnityGroupUserRemovedReason::RemovedSelf);
             }
             unlink($remove_uids_file_path);
         }

--- a/test/functional/WorkerUpdateQualifiedUsersGroupTest.php
+++ b/test/functional/WorkerUpdateQualifiedUsersGroupTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use UnityWebPortal\lib\UserFlag;
+use UnityWebPortal\lib\UnityGroupUserRemovedReason;
 
 class WorkerUpdateQualifiedUsersGroupTest extends UnityWebPortalTestCase
 {
@@ -28,7 +29,7 @@ class WorkerUpdateQualifiedUsersGroupTest extends UnityWebPortalTestCase
             $this->assertTrue($user->getFlag(UserFlag::QUALIFIED));
         } finally {
             if ($pi_group->memberUIDExists($user->uid)) {
-                $pi_group->removeUser($user);
+                $pi_group->removeUser($user, UnityGroupUserRemovedReason::RemovedSelf);
             }
             $this->assertFalse($user->getFlag(UserFlag::QUALIFIED));
         }

--- a/test/phpunit-bootstrap.php
+++ b/test/phpunit-bootstrap.php
@@ -36,6 +36,7 @@ use UnityWebPortal\lib\UnitySQL;
 use UnityWebPortal\lib\UnityHTTPDMessageLevel;
 use PHPUnit\Framework\TestCase;
 use TRegx\PhpUnit\DataProviders\DataProvider as TRegxDataProvider;
+use UnityWebPortal\lib\UnityGroupUserRemovedReason;
 
 $_SERVER["HTTP_HOST"] = "phpunit"; // used for config override
 require_once __DIR__ . "/../resources/config.php";
@@ -167,7 +168,7 @@ function ensureUserNotInPIGroup(UnityGroup $pi_group)
 {
     global $USER;
     if ($pi_group->memberUIDExists($USER->uid)) {
-        $pi_group->removeUser($USER);
+        $pi_group->removeUser($USER, UnityGroupUserRemovedReason::RemovedSelf);
         assert(!$pi_group->memberUIDExists($USER->uid));
     }
 }

--- a/webroot/admin/pi-mgmt.php
+++ b/webroot/admin/pi-mgmt.php
@@ -2,6 +2,7 @@
 
 require_once __DIR__ . "/../../resources/autoload.php";
 
+use UnityWebPortal\lib\UnityGroupUserRemovedReason;
 use UnityWebPortal\lib\UnityUser;
 use UnityWebPortal\lib\UnityGroup;
 use UnityWebPortal\lib\UnityHTTPD;
@@ -42,7 +43,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         case "remUserChild":
             $form_user = $getUserFromPost();
             $parent = new UnityGroup($_POST["pi"], $LDAP, $SQL, $MAILER);
-            $parent->removeUser($form_user);
+            $parent->removeUser($form_user, UnityGroupUserRemovedReason::RemovedByAdmin);
             break;
         case "disable":
             $group = new UnityGroup(UnityHTTPD::getPostData("pi"), $LDAP, $SQL, $MAILER);

--- a/webroot/panel/account.php
+++ b/webroot/panel/account.php
@@ -8,6 +8,7 @@ use UnityWebPortal\lib\exceptions\EncodingUnknownException;
 use UnityWebPortal\lib\exceptions\EncodingConversionException;
 use UnityWebPortal\lib\exceptions\ArrayKeyException;
 use UnityWebPortal\lib\UnitySQL;
+use UnityWebPortal\lib\UnityUserDisabledReason;
 
 $hasGroups = count($USER->getPIGroupGIDs()) > 0;
 
@@ -116,7 +117,7 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
             if ($USER->getFlag(UserFlag::DISABLED)) {
                 UnityHTTPD::badRequest("user is already disabled", "");
             }
-            $USER->disable();
+            $USER->disable(UnityUserDisabledReason::DisabledSelf);
             UnityHTTPD::messageSuccess("Account Disabled", "");
             UnityHTTPD::redirect();
             break; /** @phpstan-ignore deadCode.unreachable */

--- a/webroot/panel/groups.php
+++ b/webroot/panel/groups.php
@@ -2,6 +2,7 @@
 
 require_once __DIR__ . "/../../resources/autoload.php";
 
+use UnityWebPortal\lib\UnityGroupUserRemovedReason;
 use UnityWebPortal\lib\UnityGroup;
 use UnityWebPortal\lib\UnityHTTPD;
 
@@ -46,7 +47,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
                 break; /** @phpstan-ignore deadCode.unreachable */
             case "removePIForm":
                 $pi_account = $getPIGroupFromPost();
-                $pi_account->removeUser($USER);
+                $pi_account->removeUser($USER, UnityGroupUserRemovedReason::RemovedSelf);
                 UnityHTTPD::redirect();
                 break; /** @phpstan-ignore deadCode.unreachable */
             case "cancelPIForm":

--- a/webroot/panel/pi.php
+++ b/webroot/panel/pi.php
@@ -2,6 +2,7 @@
 
 require_once __DIR__ . "/../../resources/autoload.php";
 
+use UnityWebPortal\lib\UnityGroupUserRemovedReason;
 use UnityWebPortal\lib\UnityUser;
 use UnityWebPortal\lib\UnityHTTPD;
 use UnityWebPortal\lib\UnityGroup;
@@ -52,7 +53,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         case "remUser":
             $form_user = $getUserFromPost();
             // remove user button clicked
-            $group->removeUser($form_user);
+            $group->removeUser($form_user, UnityGroupUserRemovedReason::RemovedByOwner);
             UnityHTTPD::messageSuccess("User Removed", "");
             // group manager removed themself
             if ($USER->uid === $form_user->uid) {

--- a/workers/remove-users-from-group.php
+++ b/workers/remove-users-from-group.php
@@ -2,6 +2,7 @@
 <?php
 include __DIR__ . "/init.php";
 use Garden\Cli\Cli;
+use UnityWebPortal\lib\UnityGroupUserRemovedReason;
 use UnityWebPortal\lib\UnityUser;
 use UnityWebPortal\lib\UnityGroup;
 
@@ -26,7 +27,7 @@ try {
             print "Skipping '$uid' who doesn't appear to be in '$gid'\n";
             continue;
         }
-        $group->removeUser($user);
+        $group->removeUser($user, UnityGroupUserRemovedReason::RemovedByAdmin);
     }
 } finally {
     _fclose($handle);

--- a/workers/user-expiry.php
+++ b/workers/user-expiry.php
@@ -5,6 +5,7 @@ use Garden\Cli\Cli;
 use UnityWebPortal\lib\UnityUser;
 use UnityWebPortal\lib\UnityGroup;
 use UnityWebPortal\lib\UserFlag;
+use UnityWebPortal\lib\UnityUserDisabledReason;
 
 $cli = new Cli();
 $cli->description(
@@ -103,8 +104,7 @@ function disableUser(UnityUser $user)
     global $args;
     echo "disabling user '$user->uid'\n";
     if (!$args["dry-run"]) {
-        sendUserExpiryNoticeToPIGroupOwners("group_user_disabled_owner", $user);
-        $user->disable(send_mail_pi_group_owner: false);
+        $user->disable(UnityUserDisabledReason::Expired);
     }
 }
 


### PR DESCRIPTION
Extends the `user_flag_{added_removed}*` emails to include an explanation for why a user was disabled.
Extends the `group_user_removed_*` emails to include an explanation for why a user was removed.

closes https://github.com/UnityHPC/account-portal/issues/624

The `group_user_disabled_owner` email is no longer necessary because now the "member removed" email says they were removed because they were disabled and it says the reason why they were disabled.

TODO update list of derivative texts to include `resources/mail/group_user_removed.html.twig`