### PR TITLE
override email recipient

### DIFF
--- a/deployment/config.base.ini
+++ b/deployment/config.base.ini
@@ -114,6 +114,9 @@ sender_name = "Unity Sender"
 pi_approve = "piapproval@unitywebportal.test"  ; Only PI approval messages will go to this email
 pi_approve_name = "Unity PI Approval"
 send_pimesg_to_admins = false
+; Send all emails to this one address and nowhere else. If empty, do not override. Not for production!
+recipient_override = ""
+recipient_override_name = ""
 
 [expiry]
 idlelock_warning_days[] = 180

--- a/resources/lib/UnityMailer.php
+++ b/resources/lib/UnityMailer.php
@@ -21,6 +21,8 @@ class UnityMailer extends PHPMailer
     private string $MSG_ADMIN_NAME;
     private string $MSG_PI_APPROVAL_EMAIL;
     private string $MSG_PI_APPROVAL_NAME;
+    private string $MSG_RECIPIENT_OVERRIDE;
+    private string $MSG_RECIPIENT_OVERRIDE_NAME;
 
     private \Twig\Loader\FilesystemLoader $loader;
     private \Twig\Environment $twig;
@@ -38,6 +40,8 @@ class UnityMailer extends PHPMailer
         $this->MSG_ADMIN_NAME = CONFIG["mail"]["admin_name"];
         $this->MSG_PI_APPROVAL_EMAIL = CONFIG["mail"]["pi_approve"];
         $this->MSG_PI_APPROVAL_NAME = CONFIG["mail"]["pi_approve_name"];
+        $this->MSG_RECIPIENT_OVERRIDE = CONFIG["mail"]["recipient_override"] ?? "";
+        $this->MSG_RECIPIENT_OVERRIDE_NAME = CONFIG["mail"]["recipient_override_name"] ?? "";
         if (empty(CONFIG["smtp"]["host"])) {
             throw new Exception("SMTP server hostname not set");
         }
@@ -103,10 +107,18 @@ class UnityMailer extends PHPMailer
         $this->setFrom($this->MSG_SENDER_EMAIL, $this->MSG_SENDER_NAME);
         $this->addReplyTo($this->MSG_SUPPORT_EMAIL, $this->MSG_SUPPORT_NAME);
 
-        $mes_html = $this->twig->render("$template.html.twig", $data);
-        $this->msgHTML($mes_html);
+        $mes_html = "";
 
-        if ($recipients == "admin") {
+        if ($this->MSG_RECIPIENT_OVERRIDE !== "") {
+            $this->addBCC($this->MSG_RECIPIENT_OVERRIDE, $this->MSG_RECIPIENT_OVERRIDE_NAME);
+            $recipients_str = is_array($recipients) ? _json_encode($recipients) : $recipients;
+            $mes_html .= implode("\n", [
+                "<p>",
+                "This message has been diverted away from its original recipient(s):",
+                htmlspecialchars($recipients_str),
+                "</p>",
+            ]);
+        } elseif ($recipients == "admin") {
             $this->addBCC($this->MSG_ADMIN_EMAIL, $this->MSG_ADMIN_NAME);
         } elseif ($recipients == "pi_approve") {
             $this->addBCC($this->MSG_PI_APPROVAL_EMAIL, $this->MSG_PI_APPROVAL_NAME);
@@ -119,6 +131,9 @@ class UnityMailer extends PHPMailer
                 $this->addAddress($recipients);
             }
         }
+
+        $mes_html .= $this->twig->render("$template.html.twig", $data);
+        $this->msgHTML($mes_html);
 
         $output = parent::send();
         if ($output === false) {

--- a/resources/lib/UnityMailer.php
+++ b/resources/lib/UnityMailer.php
@@ -111,11 +111,10 @@ class UnityMailer extends PHPMailer
 
         if ($this->MSG_RECIPIENT_OVERRIDE !== "") {
             $this->addBCC($this->MSG_RECIPIENT_OVERRIDE, $this->MSG_RECIPIENT_OVERRIDE_NAME);
-            $recipients_str = is_array($recipients) ? _json_encode($recipients) : $recipients;
             $mes_html .= implode("\n", [
                 "<p>",
                 "This message has been diverted away from its original recipient(s):",
-                htmlspecialchars($recipients_str),
+                htmlspecialchars(_json_encode($recipients)),
                 "</p>",
             ]);
         } elseif ($recipients == "admin") {


### PR DESCRIPTION
I want to prevent `web-dev` from sending emails to real people.
Alternatively, I could deploy something like Mailcatcher and then change the SMTP server address to that.
I looked into postfix config but it doesn't seem like (changing recipient based on sender) is something they intended.
Coldfront has this feature, they call it `EMAIL_DEVELOPMENT_EMAIL_LIST`.

with override:

<img width="685" height="228" alt="image" src="https://github.com/user-attachments/assets/b3f5b976-85cb-4942-bdc8-1e553bba7d52" />

with override set to `""`:

<img width="653" height="195" alt="image" src="https://github.com/user-attachments/assets/a035e6e3-a892-43ab-ae45-c763d35b1be5" />

with override omitted from config file:

<img width="661" height="188" alt="image" src="https://github.com/user-attachments/assets/fbc74da3-429f-46bd-8b26-ff40de4298f4" />
