### PR TITLE
remove csv warning for .gitinclude

### DIFF
--- a/resources/lib/UnityDeployment.php
+++ b/resources/lib/UnityDeployment.php
@@ -184,7 +184,8 @@ class UnityDeployment
         $dir = new \DirectoryIterator($dir_path);
         foreach ($dir as $fileinfo) {
             $filename = $fileinfo->getFilename();
-            if ($fileinfo->isDot()) {
+            # isDot — Determine if current DirectoryIterator item is '.' or '..'
+            if ($fileinfo->isDot() || $filename === ".gitinclude") {
                 continue;
             }
             if ($fileinfo->getExtension() !== "csv") {


### PR DESCRIPTION
`[Mon Apr 13 18:30:40.538011 2026] [php:notice] [pid 1854812] [client 208.91.55.199:29263] warning: {"message":"ID map file .gitinclude ignored, extension != .csv","trace":["#0 /srv/www/unity-web-2026-4-13/resources/lib/UnityDeployment.php(191): UnityWebPortal\\\\lib\\\\UnityHTTPD::errorLog()","#1 /srv/www/unity-web-2026-4-13/resources/lib/UnityLDAP.php(75): UnityWebPortal\\\\lib\\\\UnityDeployment::getCustomIDMappings()","#2 /srv/www/unity-web-2026-4-13/resources/lib/UnityUser.php(57): UnityWebPortal\\\\lib\\\\UnityLDAP->getNextUIDGIDNumber()","#3 /srv/www/unity-web-2026-4-13/webroot/panel/new_account.php(13): UnityWebPortal\\\\lib\\\\UnityUser->init()","#4 {main}"],"REMOTE_USER":"REDACTED","REMOTE_ADDR":"REDACTED"}`