### PR TITLE
revert focus outlines to browser defaults

### DIFF
--- a/webroot/css/global.css
+++ b/webroot/css/global.css
@@ -121,17 +121,6 @@ form > * {
   display: block;
 }
 
-input:focus,
-textarea:focus,
-select:focus {
-  outline: var(--accent) solid 2px;
-}
-
-button:focus,
-input[type="submit"]:focus {
-  outline: none;
-}
-
 input[type="text"],
 input[type="password"],
 input[type="date"] {


### PR DESCRIPTION
Some elements have had their focus outlines set to the `--accent` color.

Buttons and submit inputs have had their focus outlines disabled. I can't think of any reason why this would be desirable. I assume this was done because buttons and submit inputs are already using the `--accent` color, so having an outline of the same color just makes it look bigger.



before:

https://github.com/user-attachments/assets/51031972-f290-4f82-a5d0-4fab5df1c777
		
after:

https://github.com/user-attachments/assets/5c3a00c7-2466-451a-90cb-e0b7169799a5

