### PR TITLE
enable DataTables KeyTable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "datatables.net-buttons-dt": "^3.2.6",
         "datatables.net-columncontrol-dt": "^1.2.0",
         "datatables.net-dt": "^2.3.6",
-        "datatables.net-keytable": "^2.12.2",
+        "datatables.net-keytable-dt": "^2.12.2",
         "datatables.net-responsive-dt": "^3.0.7",
         "jquery": "^3.7.1"
       },
@@ -393,6 +393,17 @@
       "license": "MIT",
       "dependencies": {
         "datatables.net": "1.11 - 2",
+        "jquery": ">=1.7"
+      }
+    },
+    "node_modules/datatables.net-keytable-dt": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/datatables.net-keytable-dt/-/datatables.net-keytable-dt-2.12.2.tgz",
+      "integrity": "sha512-TNum8l9T6k2AoTiOqeuLUDWS8wLqBNGqZQSjvHxI4IkB9IFHAYY0vIi7HZ5rvoLcbei7lLNRlYAb1hdK6MT9Aw==",
+      "license": "MIT",
+      "dependencies": {
+        "datatables.net-dt": "1.11 - 2",
+        "datatables.net-keytable": "2.12.2",
         "jquery": ">=1.7"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "datatables.net-buttons-dt": "^3.2.6",
         "datatables.net-columncontrol-dt": "^1.2.0",
         "datatables.net-dt": "^2.3.6",
+        "datatables.net-keytable": "^2.12.2",
         "datatables.net-responsive-dt": "^3.0.7",
         "jquery": "^3.7.1"
       },
@@ -382,6 +383,16 @@
       "license": "MIT",
       "dependencies": {
         "datatables.net": "2.3.6",
+        "jquery": ">=1.7"
+      }
+    },
+    "node_modules/datatables.net-keytable": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/datatables.net-keytable/-/datatables.net-keytable-2.12.2.tgz",
+      "integrity": "sha512-Fehm0/0gICdRRPBmzwFKnQaq27OXQZqcNG7ZbicZmSbu1FFO2MzDOuWzw5lD3w7mut/eZPWYm052hX45dmMIwg==",
+      "license": "MIT",
+      "dependencies": {
+        "datatables.net": "1.11 - 2",
         "jquery": ">=1.7"
       }
     },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
       "to": "webroot/js/jquery.min.js"
     },
     {
+      "from": "node_modules/datatables.net-keytable/js/dataTables.keyTable.min.js",
+      "to": "webroot/js/dataTables.keyTable.min.js"
+    },
+    {
       "from": "node_modules/datatables.net-keytable-dt/js/keyTable.dataTables.min.js",
       "to": "webroot/js/keyTable.dataTables.min.js"
     },

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
       "to": "webroot/js/jquery.min.js"
     },
     {
-      "from": "node_modules/datatables.net-keytable/js/dataTables.keyTable.min.js",
-      "to": "webroot/js/dataTables.keyTable.min.js"
+      "from": "node_modules/datatables.net-keytable-dt/js/keyTable.dataTables.min.js",
+      "to": "webroot/js/keyTable.dataTables.min.js"
     },
     {
       "from": "node_modules/datatables.net-responsive/js/dataTables.responsive.min.js",
@@ -64,6 +64,10 @@
     {
       "from": "node_modules/datatables.net-buttons-dt/css/buttons.dataTables.min.css",
       "to": "webroot/css/buttons.dataTables.min.css"
+    },
+    {
+      "from": "node_modules/datatables.net-keytable-dt/css/keyTable.dataTables.min.css",
+      "to": "webroot/css/keyTable.dataTables.min.css"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "datatables.net-buttons-dt": "^3.2.6",
     "datatables.net-columncontrol-dt": "^1.2.0",
     "datatables.net-dt": "^2.3.6",
+    "datatables.net-keytable": "^2.12.2",
     "datatables.net-responsive-dt": "^3.0.7",
     "jquery": "^3.7.1"
   },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
       "to": "webroot/js/jquery.min.js"
     },
     {
+      "from": "node_modules/datatables.net-keytable/js/dataTables.keyTable.min.js",
+      "to": "webroot/js/dataTables.keyTable.min.js"
+    },
+    {
       "from": "node_modules/datatables.net-responsive/js/dataTables.responsive.min.js",
       "to": "webroot/js/dataTables.responsive.min.js"
     },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "datatables.net-buttons-dt": "^3.2.6",
     "datatables.net-columncontrol-dt": "^1.2.0",
     "datatables.net-dt": "^2.3.6",
-    "datatables.net-keytable": "^2.12.2",
+    "datatables.net-keytable-dt": "^2.12.2",
     "datatables.net-responsive-dt": "^3.0.7",
     "jquery": "^3.7.1"
   },

--- a/resources/templates/header.html.twig
+++ b/resources/templates/header.html.twig
@@ -9,6 +9,7 @@
     'dataTables.responsive.min',
     'dataTables.buttons.min',
     'dataTables.columnControl.min',
+    'dataTables.keyTable.min',
     'buttons.print.min',
     'buttons.colVis.min',
     'buttons.html5.min',

--- a/resources/templates/header.html.twig
+++ b/resources/templates/header.html.twig
@@ -10,6 +10,7 @@
     'dataTables.buttons.min',
     'dataTables.columnControl.min',
     'dataTables.keyTable.min',
+    'keyTable.dataTables.min',
     'buttons.print.min',
     'buttons.colVis.min',
     'buttons.html5.min',
@@ -36,6 +37,7 @@
     'dataTables.dataTables.min',
     'columnControl.dataTables.min',
     'buttons.dataTables.min',
+    'keyTable.dataTables.min',
   ] %}
   {% for x in stylesheets %}
     {% set url = getRelativeURL('css/' ~ x ~ '.css?cache_bust_increment_me=' ~ CONFIG['upstream']['version']) %}

--- a/webroot/admin/pi-mgmt.php
+++ b/webroot/admin/pi-mgmt.php
@@ -163,6 +163,7 @@ $CSRFTokenHiddenFormInput = UnityHTTPD::getCSRFTokenHiddenFormInput();
 <script>
     $(document).ready(() => {
         let pi_request_datatable = $('#pi-request-table').DataTable({
+            keys: true,
             responsive: true,
             stateSave: true,
             columns: [
@@ -174,6 +175,7 @@ $CSRFTokenHiddenFormInput = UnityHTTPD::getCSRFTokenHiddenFormInput();
             ],
         });
         let pi_datatable = $('#pi-table').DataTable({
+            keys: true,
             stateSave: true,
             columns: [
                 {className: 'details-control'}, // name

--- a/webroot/admin/user-mgmt.php
+++ b/webroot/admin/user-mgmt.php
@@ -103,6 +103,7 @@ $flags_to_display = array_filter(UserFlag::cases(), fn($x) => $x !== UserFlag::D
 <script>
 $(document).ready(() => {
     $('#user-table').DataTable({
+        keys: true,
         stateSave: true,
         responsive: true,
         columns: [

--- a/webroot/panel/groups.php
+++ b/webroot/panel/groups.php
@@ -233,6 +233,7 @@ echo "</table>";
 <script>
     $(document).ready(() => {
         $('#pi-table').DataTable({
+            keys: true,
             stateSave: true,
             responsive: true,
             columns: [
@@ -245,6 +246,7 @@ echo "</table>";
             layout: {topStart: {buttons: ['colvis']}}
         });
         $('#pi-request-table').DataTable({
+            keys: true,
             stateSave: true,
             responsive: true,
             columns: [

--- a/webroot/panel/pi.php
+++ b/webroot/panel/pi.php
@@ -227,6 +227,7 @@ echo "</form></div>";
 <script>
     $(document).ready(() => {
         $('#users-table').DataTable({
+            keys: true,
             stateSave: true,
             responsive: true,
             columns: [


### PR DESCRIPTION
Enables excel-style table navigation using arrow keys.

This navigation seems to be completely separate from the screen reader focus.

https://github.com/user-attachments/assets/e7160ef4-c169-4f06-9b51-3677e4ceb1af
