### PR TITLE
make "active" navbar link pop

### DIFF
--- a/webroot/css/navbar.css
+++ b/webroot/css/navbar.css
@@ -35,7 +35,7 @@ nav.mainNav a:hover {
 }
 
 nav.mainNav a.active {
-  background: var(--accent_2);
+  border: 2px solid var(--accent_foreground);
 }
 
 header {

--- a/webroot/js/global-late.js
+++ b/webroot/js/global-late.js
@@ -50,7 +50,7 @@
       href = href.substring(href.lastIndexOf("/") + 1);
     }
 
-    if (url.indexOf(href) === 0) {
+    if (url === href) {
       $(this).addClass("active");
     }
   });


### PR DESCRIPTION
I had no idea that the active navbar link was highlighted until I stumbled upon the code.

Also fixes a bug where `pi.php` is highlighted when the current page is `pi-mgmt.php`.

before:

<img width="455" height="254" alt="image" src="https://github.com/user-attachments/assets/b1ea9033-7948-4608-9bf8-aa0ff5530894" />

after:

<img width="395" height="315" alt="image" src="https://github.com/user-attachments/assets/8c7a049a-a570-44ed-b0d2-9bff86d5634d" />
