### PR TITLE
refactor PI group filters

### DIFF
--- a/resources/lib/UnityLDAP.php
+++ b/resources/lib/UnityLDAP.php
@@ -32,7 +32,8 @@ class UnityLDAP extends LDAPConn
     ];
 
     // isDisabled unset or set to "FALSE"
-    private static string $NON_DISABLED_FILTER = "(|(!(isDisabled=*))(isDisabled=FALSE))";
+    public const NON_DISABLED = "(|(!(isDisabled=*))(isDisabled=FALSE))";
+    public const INCLUDE_DISABLED = "(objectClass=*)";
 
     private string $def_user_shell = CONFIG["ldap"]["def_user_shell"];
     private int $offset_UIDGID = CONFIG["ldap"]["offset_UIDGID"];
@@ -170,13 +171,16 @@ class UnityLDAP extends LDAPConn
     }
 
     /** @return UnityGroup[] */
-    public function getAllNonDisabledPIGroups(UnitySQL $UnitySQL, UnityMailer $UnityMailer)
-    {
+    public function getPIGroups(
+        UnitySQL $UnitySQL,
+        UnityMailer $UnityMailer,
+        string $filter = self::NON_DISABLED,
+    ) {
         $out = [];
         $pi_groups_attributes = $this->pi_groupOU->getChildrenArrayStrict(
             attributes: ["cn"],
             recursive: false,
-            filter: self::$NON_DISABLED_FILTER,
+            filter: $filter,
         );
         foreach ($pi_groups_attributes as $attributes) {
             array_push($out, new UnityGroup($attributes["cn"][0], $this, $UnitySQL, $UnityMailer));
@@ -189,30 +193,35 @@ class UnityLDAP extends LDAPConn
      * @param attributes $default_values
      * @return attributes[]
      */
-    public function getAllNonDisabledPIGroupsAttributes(
+    public function getPIGroupsAttributes(
         array $attributes,
         array $default_values = [],
+        string $filter = self::NON_DISABLED,
     ): array {
         return $this->pi_groupOU->getChildrenArrayStrict(
             $attributes,
             false, // non-recursive
-            self::$NON_DISABLED_FILTER,
+            $filter,
             $default_values,
         );
     }
 
     /** @return string[] */
-    public function getNonDisabledPIGroupGIDsWithMemberUID(string $uid): array
-    {
+    public function getPIGroupGIDsWithMemberUID(
+        string $uid,
+        string $filter = self::NON_DISABLED,
+    ): array {
         return array_map(
             fn($x) => (string) $x["cn"][0],
-            $this->getNonDisabledPIGroupAttributesWithMemberUID($uid, ["cn"]),
+            $this->getPIGroupAttributesWithMemberUID($uid, ["cn"], base_filter: $filter),
         );
     }
 
     /** @return string[] */
-    public function getNonDisabledPIGroupGIDsWithManagerUID(string $uid): array
-    {
+    public function getPIGroupGIDsWithManagerUID(
+        string $uid,
+        string $base_filter = self::NON_DISABLED,
+    ): array {
         return array_map(
             fn($x) => $x["cn"][0],
             $this->pi_groupOU->getChildrenArrayStrict(
@@ -221,18 +230,18 @@ class UnityLDAP extends LDAPConn
                 sprintf(
                     "(&(manageruid=%s)%s)",
                     ldap_escape($uid, flags: LDAP_ESCAPE_FILTER),
-                    self::$NON_DISABLED_FILTER,
+                    $base_filter,
                 ),
             ),
         );
     }
 
     /** @return string[] */
-    public function getAllNonDisabledPIGroupOwnerUIDs(): array
+    public function getPIGroupOwnerUIDs(string $filter = self::NON_DISABLED): array
     {
         return array_map(
             fn($x) => UnityGroup::GID2OwnerUID((string) $x["cn"][0]),
-            $this->getAllNonDisabledPIGroupsAttributes(["cn"]),
+            $this->getPIGroupsAttributes(["cn"], filter: $filter),
         );
     }
 
@@ -241,10 +250,11 @@ class UnityLDAP extends LDAPConn
      * @param attributes $default_values
      * @return attributes[]
      */
-    public function getNonDisabledPIGroupAttributesWithMemberUID(
+    public function getPIGroupAttributesWithMemberUID(
         string $uid,
         array $attributes,
         array $default_values = [],
+        string $base_filter = self::NON_DISABLED,
     ) {
         return $this->pi_groupOU->getChildrenArrayStrict(
             $attributes,
@@ -252,7 +262,7 @@ class UnityLDAP extends LDAPConn
             filter: sprintf(
                 "(&(memberuid=%s)%s)",
                 ldap_escape($uid, "", LDAP_ESCAPE_FILTER),
-                self::$NON_DISABLED_FILTER,
+                $base_filter,
             ),
             default_values: $default_values,
         );
@@ -266,7 +276,7 @@ class UnityLDAP extends LDAPConn
     {
         $uid2pigids = [];
         // for each PI group, append that GID to the member list for each of its member UIDs
-        $pi_groups_attributes = $this->getAllNonDisabledPIGroupsAttributes(
+        $pi_groups_attributes = $this->getPIGroupsAttributes(
             ["cn", "memberuid"],
             default_values: ["memberuid" => []],
         );

--- a/resources/lib/UnityUser.php
+++ b/resources/lib/UnityUser.php
@@ -391,7 +391,7 @@ class UnityUser
      */
     public function getPIGroupGIDs(): array
     {
-        return $this->LDAP->getNonDisabledPIGroupGIDsWithMemberUID($this->uid);
+        return $this->LDAP->getPIGroupGIDsWithMemberUID($this->uid);
     }
 
     /**
@@ -422,7 +422,7 @@ class UnityUser
         if ($pi_group->exists() && !$pi_group->getIsDisabled()) {
             $pi_group->disable($send_mail);
         }
-        foreach ($this->LDAP->getNonDisabledPIGroupGIDsWithMemberUID($this->uid) as $gid) {
+        foreach ($this->LDAP->getPIGroupGIDsWithMemberUID($this->uid) as $gid) {
             $group = new UnityGroup($gid, $this->LDAP, $this->SQL, $this->MAILER);
             $group->removeUser($this, $why, send_mail: $send_mail_pi_group_owner);
         }

--- a/test/functional/PIDisableTest.php
+++ b/test/functional/PIDisableTest.php
@@ -59,7 +59,7 @@ class PIDisableTest extends UnityWebPortalTestCase
     {
         global $USER, $LDAP, $SQL, $MAILER;
         $this->switchUser("CourseGroupManager");
-        $managed_groups = $LDAP->getNonDisabledPIGroupGIDsWithManagerUID($USER->uid);
+        $managed_groups = $LDAP->getPIGroupGIDsWithManagerUID($USER->uid);
         $this->assertNotEmpty($managed_groups);
         $gid = $managed_groups[0];
         $group = new UnityGroup($gid, $LDAP, $SQL, $MAILER);

--- a/test/functional/PIRemoveUserTest.php
+++ b/test/functional/PIRemoveUserTest.php
@@ -117,7 +117,7 @@ class PIRemoveUserTest extends UnityWebPortalTestCase
     {
         global $USER, $LDAP, $SQL, $MAILER;
         $this->switchUser("CourseGroupManager");
-        $managed_groups = $LDAP->getNonDisabledPIGroupGIDsWithManagerUID($USER->uid);
+        $managed_groups = $LDAP->getPIGroupGIDsWithManagerUID($USER->uid);
         $this->assertNotEmpty($managed_groups);
         $gid = $managed_groups[0];
         $group = new UnityGroup($gid, $LDAP, $SQL, $MAILER);

--- a/test/functional/PageLoadTest.php
+++ b/test/functional/PageLoadTest.php
@@ -76,7 +76,7 @@ class PageLoadTest extends UnityWebPortalTestCase
     {
         global $LDAP, $USER;
         $this->switchUser("CourseGroupManager");
-        $gids = $LDAP->getNonDisabledPIGroupGIDsWithManagerUID($USER->uid);
+        $gids = $LDAP->getPIGroupGIDsWithManagerUID($USER->uid);
         $this->assertTrue(count($gids) > 0);
         $gid = $gids[0];
         $output = $this->http_get(__DIR__ . "/../../webroot/panel/pi.php", [
@@ -132,7 +132,7 @@ class PageLoadTest extends UnityWebPortalTestCase
     {
         global $USER, $LDAP;
         $this->switchUser("CourseGroupManager");
-        $gids = $LDAP->getNonDisabledPIGroupGIDsWithManagerUID($USER->uid);
+        $gids = $LDAP->getPIGroupGIDsWithManagerUID($USER->uid);
         $this->assertTrue(count($gids) > 0);
         $output = $this->http_get(__DIR__ . "/../../webroot/panel/groups.php");
         foreach ($gids as $gid) {

--- a/test/phpunit-bootstrap.php
+++ b/test/phpunit-bootstrap.php
@@ -142,7 +142,7 @@ function ensureUserDoesNotExist(string $uid)
             $flag_group->removeMemberUID($uid);
         }
     }
-    foreach ($LDAP->getNonDisabledPIGroupGIDsWithMemberUID($uid) as $gid) {
+    foreach ($LDAP->getPIGroupGIDsWithMemberUID($uid) as $gid) {
         $pi_group_entry = $LDAP->getPIGroupEntry($gid);
         $pi_group_members = $pi_group_entry->getAttribute("memberuid");
         if (in_array($uid, $pi_group_members)) {
@@ -286,7 +286,7 @@ class UnityWebPortalTestCase extends TestCase
                 $this->assertNotEmpty($USER->getPIGroup()->getManagerUIDs());
                 break;
             case "CourseGroupManager":
-                $this->assertNotEmpty($LDAP->getNonDisabledPIGroupGIDsWithManagerUID($USER->uid));
+                $this->assertNotEmpty($LDAP->getPIGroupGIDsWithManagerUID($USER->uid));
                 break;
             case "CustomMapped555":
                 $this->assertFalse($USER->exists());

--- a/webroot/admin/pi-mgmt.php
+++ b/webroot/admin/pi-mgmt.php
@@ -123,7 +123,7 @@ $CSRFTokenHiddenFormInput = UnityHTTPD::getCSRFTokenHiddenFormInput();
     </thead>
     <tbody>
     <?php
-    $owner_uids = $LDAP->getAllNonDisabledPIGroupOwnerUIDs();
+    $owner_uids = $LDAP->getPIGroupOwnerUIDs();
     $owner_attributes = $LDAP->getUsersAttributes(
         $owner_uids,
         ["uid", "gecos", "mail"],

--- a/webroot/panel/groups.php
+++ b/webroot/panel/groups.php
@@ -69,7 +69,7 @@ $CSRFTokenHiddenFormInput = UnityHTTPD::getCSRFTokenHiddenFormInput();
 
 <?php
 $PIGroupGIDs = [];
-$PIGroupAttributes = $LDAP->getNonDisabledPIGroupAttributesWithMemberUID(
+$PIGroupAttributes = $LDAP->getPIGroupAttributesWithMemberUID(
     $USER->uid,
     ["cn", "memberuid", "manageruid"],
     default_values: ["memberuid" => [], "manageruid" => []]

--- a/webroot/panel/modal/new_pi.php
+++ b/webroot/panel/modal/new_pi.php
@@ -7,7 +7,7 @@ $CSRFTokenHiddenFormInput = UnityHTTPD::getCSRFTokenHiddenFormInput();
 
 // cache PI group info in $_SESSION for ajax pi_search.php
 // cache persists only until the user loads this page again
-$owner_uids = $LDAP->getAllNonDisabledPIGroupOwnerUIDs();
+$owner_uids = $LDAP->getPIGroupOwnerUIDs();
 $owner_attributes = $LDAP->getUsersAttributes(
     $owner_uids,
     ["uid", "gecos", "mail"],

--- a/workers/ensure-all-pi-groups-have-objectClass.php
+++ b/workers/ensure-all-pi-groups-have-objectClass.php
@@ -3,6 +3,7 @@
 include __DIR__ . "/init.php";
 
 use Garden\Cli\Cli;
+use UnityWebPortal\lib\UnityLDAP;
 
 $cli = new Cli();
 $cli->description("Ensure that all PI groups have the 'piGroup' objectClass.")->opt(
@@ -13,7 +14,10 @@ $cli->description("Ensure that all PI groups have the 'piGroup' objectClass.")->
 );
 $args = $cli->parse($argv, true);
 
-foreach ($LDAP->getAllNonDisabledPIGroupsAttributes(["cn", "objectclass"]) as $attributes) {
+foreach (
+    $LDAP->getPIGroupsAttributes(["cn", "objectclass"], filter: UnityLDAP::INCLUDE_DISABLED)
+    as $attributes
+) {
     if (!in_array("piGroup", $attributes["objectclass"])) {
         $gid = $attributes["cn"][0];
         echo "adding value to objectClass of group '$gid'\n";

--- a/workers/group_user_request_owner_reminder.php
+++ b/workers/group_user_request_owner_reminder.php
@@ -9,7 +9,7 @@ include __DIR__ . "/init.php";
 use UnityWebPortal\lib\UnityGroup;
 
 $today = time();
-$accounts = $LDAP->getAllNonDisabledPIGroups($SQL, $MAILER);
+$accounts = $LDAP->getPIGroups($SQL, $MAILER);
 foreach ($accounts as $pi_group) {
     $pi_user = $pi_group->getOwner();
     $requests = $pi_group->getRequests();

--- a/workers/update-qualified-users-group.php
+++ b/workers/update-qualified-users-group.php
@@ -13,10 +13,7 @@ $cli->description("Add and remove users from the qualified user group.")->opt(
 $args = $cli->parse($argv, true);
 
 $qualified_list_before = $LDAP->userFlagGroups["qualified"]->getMemberUIDs();
-$pi_groups_attributes = $LDAP->getAllNonDisabledPIGroupsAttributes(
-    ["memberuid"],
-    ["memberuid" => []],
-);
+$pi_groups_attributes = $LDAP->getPIGroupsAttributes(["memberuid"], ["memberuid" => []]);
 $users_with_at_least_one_group = array_merge(
     ...array_map(fn($x) => $x["memberuid"], $pi_groups_attributes),
 );

--- a/workers/user-expiry.php
+++ b/workers/user-expiry.php
@@ -43,10 +43,7 @@ foreach ($uid_to_last_login as $uid => $last_login) {
 }
 
 $pi_group_members = [];
-foreach (
-    $LDAP->getAllNonDisabledPIGroupsAttributes(["cn", "memberuid"], ["memberuid" => []])
-    as $attributes
-) {
+foreach ($LDAP->getPIGroupsAttributes(["cn", "memberuid"], ["memberuid" => []]) as $attributes) {
     $pi_group_members[$attributes["cn"][0]] = $attributes["memberuid"];
 }
 $pi_group_owners = array_map(UnityGroup::GID2OwnerUID(...), array_keys($pi_group_members));
@@ -77,7 +74,7 @@ function sendMail(array|string $recipients, string $template, ?array $data = nul
 function sendUserExpiryNoticeToPIGroupOwners(string $template, UnityUser $user)
 {
     global $LDAP, $SQL, $MAILER;
-    foreach ($LDAP->getNonDisabledPIGroupGIDsWithMemberUID($user->uid) as $gid) {
+    foreach ($LDAP->getPIGroupGIDsWithMemberUID($user->uid) as $gid) {
         $group = new UnityGroup($gid, $LDAP, $SQL, $MAILER);
         sendMail($group->getOwnerMailAndPlusAddressedManagerMails(), $template, [
             "group" => $gid,


### PR DESCRIPTION
there is a bug here:

https://github.com/UnityHPC/account-portal/blob/6b69cb451c0ed63c390b247f1858f3528d462a48/workers/ensure-all-pi-groups-have-objectClass.php#L16

`ensure-all-pi-groups-have-objectClass.php` should not overlook disabled PI groups.

To fix this, I could create an alternative `UnityLDAP::getAllPIGroupsAttributes`. But I don't want to create a foot-gun in the future where I accidentally use this alternative function when I actually should be overlooking disabled PI groups. Instead, I make the filter an argument, with `NON_DISABLED` as the default value. This way, I don't have to add any new functions, the long function name `getAllNonDisabledPIGroupsAttributes` gets shorter, and no foot-guns are created.