### PR TITLE
one user can own multiple PI groups

### DIFF
--- a/.phpcs-ruleset-pure.xml
+++ b/.phpcs-ruleset-pure.xml
@@ -22,4 +22,7 @@
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
         <exclude name="PSR1.Classes.ClassDeclaration.MultipleClasses" />
     </rule>
+    <rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
+        <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps" />
+    </rule>
 </ruleset>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For details on the changes in each release, see [the Releases page](https://gith
   - the new LDAP schema should be added in conjunction with the old
   - all entries should have the `piGroup` objectClass replaced with `unityGroup`
   - the `setup-pi-group-owners.php` worker should be run
+- all existing PI requests in SQL must be converted to the format "owner_uid:group_gid"
 
 ### 1.7 -> 1.8
 - the [webhook] section of the config file can be removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ For details on the changes in each release, see [the Releases page](https://gith
   - the new LDAP schema should be added in conjunction with the old
   - all entries should have the `piGroup` objectClass replaced with `unityGroup`
   - the `setup-pi-group-owners.php` worker should be run
-- all existing PI requests in SQL must be converted to the format "owner_uid:group_gid"
+- all existing PI group requests in SQL must be converted to the format "owner_uid:group_gid"
+- ownership of any course groups should be transferred to a Unity admin
+- dummy course group owners should be deleted
 
 ### 1.7 -> 1.8
 - the [webhook] section of the config file can be removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ For details on the changes in each release, see [the Releases page](https://gith
 
 ## Version-specific update instructions:
 
+### 1.8 -> 1.9
+- schema migration:
+  - the new LDAP schema should be added in conjunction with the old
+  - all entries should have the `piGroup` objectClass replaced with `unityGroup`
+  - once entries are migrated, the `piGroup` objectClass should be removed from the production schema
+  - the `setup-pi-group-owners.php` worker should be run
+
 ### 1.7 -> 1.8
 - the [webhook] section of the config file can be removed
 - all mail templates are no longer PHP files, now they are `.html.twig`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ For details on the changes in each release, see [the Releases page](https://gith
 - schema migration:
   - the new LDAP schema should be added in conjunction with the old
   - all entries should have the `piGroup` objectClass replaced with `unityGroup`
-  - once entries are migrated, the `piGroup` objectClass should be removed from the production schema
   - the `setup-pi-group-owners.php` worker should be run
 
 ### 1.7 -> 1.8

--- a/deployment/domain_overrides/course-creator/config.ini
+++ b/deployment/domain_overrides/course-creator/config.ini
@@ -1,6 +1,5 @@
-# we have hacked in course groups using normal PI accounts but using a different IDnumber range
+# we have hacked in course groups using normal PI groups but using a different IDnumber range
 [ldap]
-offset_UIDGID = 20000
 offset_PIGID = 20000
 
 [site]

--- a/resources/init.php
+++ b/resources/init.php
@@ -80,7 +80,7 @@ if (isset($_SERVER["REMOTE_USER"])) {
     }
 
     $_SESSION["user_exists"] = $USER->exists() && !$USER->getFlag(UserFlag::DISABLED);
-    $_SESSION["is_pi"] = $USER->isPI();
+    $_SESSION["owned_managed_pi_group_gids"] = $USER->getOwnedPIGroupGIDs();
 
     $days_idle = $SQL->convertLastLoginToDaysIdle($SQL->getUserLastLogin($USER->uid));
     $SQL->addLog("user_login", $OPERATOR->uid);

--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -107,9 +107,7 @@ class UnityGroup extends PosixGroup
             $this->MAILER->sendMail(
                 $this->getOwnerMailAndPlusAddressedManagerMails(),
                 "group_reenabled",
-                [
-                    "group_name" => $this->gid,
-                ],
+                ["group_name" => $this->gid],
             );
         }
         $this->setIsDisabled(false);

--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -104,9 +104,13 @@ class UnityGroup extends PosixGroup
         }
         $this->SQL->addLog("reenabled_pi_group", $this->gid);
         if ($send_mail) {
-            $this->MAILER->sendMail($this->getOwnerMailAndManagerMails(), "group_reenabled", [
-                "group_name" => $this->gid,
-            ]);
+            $this->MAILER->sendMail(
+                $this->getOwnerMailAndPlusAddressedManagerMails(),
+                "group_reenabled",
+                [
+                    "group_name" => $this->gid,
+                ],
+            );
         }
         $this->setIsDisabled(false);
         $owner_uid = $this->getOwner()->uid;
@@ -184,7 +188,7 @@ class UnityGroup extends PosixGroup
         $this->SQL->removeRequest($user->uid, $this->gid);
         if ($send_mail) {
             $this->MAILER->sendMail(
-                $this->getOwnerMailAndManagerMails(),
+                $this->getOwnerMailAndPlusAddressedManagerMails(),
                 "group_join_request_cancelled",
                 ["uid" => $user->uid],
             );
@@ -210,7 +214,7 @@ class UnityGroup extends PosixGroup
                 "group" => $this->gid,
             ]);
             $this->MAILER->sendMail(
-                $this->getOwnerMailAndManagerMails(),
+                $this->getOwnerMailAndPlusAddressedManagerMails(),
                 "group_user_added_owner",
                 [
                     "group" => $this->gid,
@@ -238,7 +242,7 @@ class UnityGroup extends PosixGroup
                 "group" => $this->gid,
             ]);
             $this->MAILER->sendMail(
-                $this->getOwnerMailAndManagerMails(),
+                $this->getOwnerMailAndPlusAddressedManagerMails(),
                 "group_user_denied_owner",
                 [
                     "group" => $this->gid,
@@ -273,7 +277,7 @@ class UnityGroup extends PosixGroup
                 "why" => $why,
             ]);
             $this->MAILER->sendMail(
-                $this->getOwnerMailAndManagerMails(),
+                $this->getOwnerMailAndPlusAddressedManagerMails(),
                 "group_user_removed_owner",
                 [
                     "group" => $this->gid,
@@ -305,7 +309,7 @@ class UnityGroup extends PosixGroup
                 "group" => $this->gid,
             ]);
             $this->MAILER->sendMail(
-                $this->getOwnerMailAndManagerMails(),
+                $this->getOwnerMailAndPlusAddressedManagerMails(),
                 "group_user_request_owner",
                 [
                     "group" => $this->gid,
@@ -480,13 +484,23 @@ class UnityGroup extends PosixGroup
         parent::removeMemberUID($uid);
     }
 
+    public function addPlusAddressToMail(string $mail): string
+    {
+        $owner = $this->getOwner();
+        $suffix = "_" . $owner->getOrg();
+        assert(str_ends_with($owner->uid, $suffix));
+        $short_name = substr($owner->uid, 0, -(1 * strlen($suffix)));
+        $parts = explode("@", $mail, 2);
+        return sprintf("%s+%s@%s", $parts[0], $short_name, $parts[1]);
+    }
+
     /** @return string[] */
-    public function getOwnerMailAndManagerMails(): array
+    public function getOwnerMailAndPlusAddressedManagerMails(): array
     {
         $mails = [$this->getOwner()->getMail()];
         foreach ($this->getManagerUIDs() as $manager_uid) {
             $manager = new UnityUser($manager_uid, $this->LDAP, $this->SQL, $this->MAILER);
-            array_push($mails, $manager->getMail());
+            array_push($mails, $this->addPlusAddressToMail($manager->getMail()));
         }
         $mails = array_unique($mails);
         sort($mails);

--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -17,7 +17,7 @@ enum UnityGroupUserRemovedReason: string
  */
 class UnityGroup extends PosixGroup
 {
-    public const string PI_PREFIX = "pi_";
+    public const string NAMESAKE_PI_PREFIX = "pi_";
     public string $gid;
     private UnityLDAP $LDAP;
     private UnitySQL $SQL;
@@ -368,25 +368,20 @@ class UnityGroup extends PosixGroup
 
     public function getOwner(): UnityUser
     {
-        return new UnityUser(
-            self::GID2OwnerUID($this->gid),
-            $this->LDAP,
-            $this->SQL,
-            $this->MAILER,
-        );
+        return $this->entry->getAttribute("ownerUid")[0];
     }
 
-    public static function ownerUID2GID(string $uid): string
+    public static function ownerUID2NamesakeGID(string $uid): string
     {
-        return self::PI_PREFIX . $uid;
+        return self::NAMESAKE_PI_PREFIX . $uid;
     }
 
-    public static function GID2OwnerUID(string $gid): string
+    public static function NamesakeGID2OwnerUID(string $gid): string
     {
-        if (substr($gid, 0, strlen(self::PI_PREFIX)) != self::PI_PREFIX) {
+        if (substr($gid, 0, strlen(self::NAMESAKE_PI_PREFIX)) != self::NAMESAKE_PI_PREFIX) {
             throw new Exception("PI group GID doesn't have the correct prefix.");
         }
-        return substr($gid, strlen(self::PI_PREFIX));
+        return substr($gid, strlen(self::NAMESAKE_PI_PREFIX));
     }
 
     /**

--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -376,7 +376,8 @@ class UnityGroup extends PosixGroup
 
     public function getOwner(): UnityUser
     {
-        return $this->entry->getAttribute("ownerUid")[0];
+        $uid = $this->entry->getAttribute("ownerUid")[0];
+        return new UnityUser($uid, $this->LDAP, $this->SQL, $this->MAILER);
     }
 
     public static function ownerUID2NamesakeGID(string $uid): string

--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -150,7 +150,7 @@ class UnityGroup extends PosixGroup
         assert($this->SQL->requestExists($request, UnitySQL::REQUEST_CREATE_PI_GROUP));
         $owner = new UnityUser($owner_uid, $this->LDAP, $this->SQL, $this->MAILER);
         assert($owner->exists());
-        $this->SQL->removeRequest($owner_uid, UnitySQL::REQUEST_CREATE_PI_GROUP);
+        $this->SQL->removeRequest($request, UnitySQL::REQUEST_CREATE_PI_GROUP);
         if ($this->exists()) {
             return;
         }

--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -352,9 +352,10 @@ class UnityGroup extends PosixGroup
         assert(!$this->entry->exists());
         $nextGID = $this->LDAP->getNextPIGIDNumber();
         $this->entry->create([
-            "objectclass" => ["piGroup", "posixGroup", "top"],
+            "objectclass" => ["unityGroup", "posixGroup", "top"],
             "gidnumber" => strval($nextGID),
             "memberuid" => [$owner->uid],
+            "owneruid" => $owner->uid,
         ]);
         // TODO if we ever make this project based,
         // we need to update the cache here with the memberuid
@@ -480,7 +481,7 @@ class UnityGroup extends PosixGroup
         $owner = $this->getOwner();
         $suffix = "_" . $owner->getOrg();
         assert(str_ends_with($owner->uid, $suffix));
-        $short_name = substr($owner->uid, 0, -1 * strlen($suffix));
+        $short_name = substr($owner->uid, 0, -strlen($suffix));
         $parts = explode("@", $mail, 2);
         return sprintf("%s+%s@%s", $parts[0], $short_name, $parts[1]);
     }

--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -104,11 +104,9 @@ class UnityGroup extends PosixGroup
         }
         $this->SQL->addLog("reenabled_pi_group", $this->gid);
         if ($send_mail) {
-            $this->MAILER->sendMail(
-                $this->getOwnerMailAndPlusAddressedManagerMails(),
-                "group_reenabled",
-                ["group_name" => $this->gid],
-            );
+            $this->MAILER->sendMail($this->getOwnerMailAndManagerMails(), "group_reenabled", [
+                "group_name" => $this->gid,
+            ]);
         }
         $this->setIsDisabled(false);
         $owner_uid = $this->getOwner()->uid;
@@ -186,7 +184,7 @@ class UnityGroup extends PosixGroup
         $this->SQL->removeRequest($user->uid, $this->gid);
         if ($send_mail) {
             $this->MAILER->sendMail(
-                $this->getOwnerMailAndPlusAddressedManagerMails(),
+                $this->getOwnerMailAndManagerMails(),
                 "group_join_request_cancelled",
                 ["uid" => $user->uid],
             );
@@ -212,7 +210,7 @@ class UnityGroup extends PosixGroup
                 "group" => $this->gid,
             ]);
             $this->MAILER->sendMail(
-                $this->getOwnerMailAndPlusAddressedManagerMails(),
+                $this->getOwnerMailAndManagerMails(),
                 "group_user_added_owner",
                 [
                     "group" => $this->gid,
@@ -240,7 +238,7 @@ class UnityGroup extends PosixGroup
                 "group" => $this->gid,
             ]);
             $this->MAILER->sendMail(
-                $this->getOwnerMailAndPlusAddressedManagerMails(),
+                $this->getOwnerMailAndManagerMails(),
                 "group_user_denied_owner",
                 [
                     "group" => $this->gid,
@@ -275,7 +273,7 @@ class UnityGroup extends PosixGroup
                 "why" => $why,
             ]);
             $this->MAILER->sendMail(
-                $this->getOwnerMailAndPlusAddressedManagerMails(),
+                $this->getOwnerMailAndManagerMails(),
                 "group_user_removed_owner",
                 [
                     "group" => $this->gid,
@@ -307,7 +305,7 @@ class UnityGroup extends PosixGroup
                 "group" => $this->gid,
             ]);
             $this->MAILER->sendMail(
-                $this->getOwnerMailAndPlusAddressedManagerMails(),
+                $this->getOwnerMailAndManagerMails(),
                 "group_user_request_owner",
                 [
                     "group" => $this->gid,
@@ -481,23 +479,13 @@ class UnityGroup extends PosixGroup
         parent::removeMemberUID($uid);
     }
 
-    public function addPlusAddressToMail(string $mail): string
-    {
-        $owner = $this->getOwner();
-        $suffix = "_" . $owner->getOrg();
-        assert(str_ends_with($owner->uid, $suffix));
-        $short_name = substr($owner->uid, 0, -strlen($suffix));
-        $parts = explode("@", $mail, 2);
-        return sprintf("%s+%s@%s", $parts[0], $short_name, $parts[1]);
-    }
-
     /** @return string[] */
-    public function getOwnerMailAndPlusAddressedManagerMails(): array
+    public function getOwnerMailAndManagerMails(): array
     {
         $mails = [$this->getOwner()->getMail()];
         foreach ($this->getManagerUIDs() as $manager_uid) {
             $manager = new UnityUser($manager_uid, $this->LDAP, $this->SQL, $this->MAILER);
-            array_push($mails, $this->addPlusAddressToMail($manager->getMail()));
+            array_push($mails, $manager->getMail());
         }
         $mails = array_unique($mails);
         sort($mails);

--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -355,7 +355,7 @@ class UnityGroup extends PosixGroup
         return false;
     }
 
-    private function init($owner_uid): void
+    private function init(string $owner_uid): void
     {
         assert(!$this->entry->exists());
         $nextGID = $this->LDAP->getNextPIGIDNumber();

--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -37,21 +37,25 @@ class UnityGroup extends PosixGroup
         return $this->gid;
     }
 
-    public function requestGroup(?bool $send_mail_to_admins = null, bool $send_mail = true): void
-    {
+    public function requestGroup(
+        string $owner_uid,
+        ?bool $send_mail_to_admins = null,
+        bool $send_mail = true,
+    ): void {
         $send_mail_to_admins ??= CONFIG["mail"]["send_pimesg_to_admins"];
         if ($this->exists() && !$this->getIsDisabled()) {
             return;
         }
+        $owner = new UnityUser($owner_uid, $this->LDAP, $this->SQL, $this->MAILER);
         $context = [
-            "user" => $this->getOwner()->uid,
-            "org" => $this->getOwner()->getOrg(),
-            "name" => $this->getOwner()->getFullName(),
-            "email" => $this->getOwner()->getMail(),
+            "user" => $owner_uid,
+            "org" => $owner->getOrg(),
+            "name" => $owner->getFullName(),
+            "email" => $owner->getMail(),
         ];
-        $this->SQL->addRequest($this->getOwner()->uid, UnitySQL::REQUEST_BECOME_PI);
+        $this->SQL->addRequest("$owner_uid:$this->gid", UnitySQL::REQUEST_CREATE_PI_GROUP);
         if ($send_mail) {
-            $this->MAILER->sendMail($this->getOwner()->getMail(), "group_request");
+            $this->MAILER->sendMail($owner->getMail(), "group_request");
             if ($send_mail_to_admins) {
                 $this->MAILER->sendMail("admin", "group_request_admin", $context);
             }
@@ -117,52 +121,59 @@ class UnityGroup extends PosixGroup
     /**
      * This method will create the group (this is what is executed when an admin approved the group)
      */
-    public function approveGroup(bool $send_mail = true): void
+    public function approveGroup(string $owner_uid, bool $send_mail = true): void
     {
-        $uid = $this->getOwner()->uid;
-        $request = $this->SQL->getRequest($uid, UnitySQL::REQUEST_BECOME_PI);
-        assert($this->getOwner()->exists());
+        $request = "$owner_uid:$this->gid";
+        assert($this->SQL->requestExists($request, UnitySQL::REQUEST_CREATE_PI_GROUP));
+        $owner = new UnityUser($owner_uid, $this->LDAP, $this->SQL, $this->MAILER);
+        assert($owner->exists());
         if (!$this->entry->exists()) {
-            $this->init();
+            $this->init($owner_uid);
         } elseif ($this->getIsDisabled()) {
             $this->reenable();
         } else {
             throw new Exception("cannot approve group that already exists and is not disabled");
         }
-        $this->SQL->removeRequest($this->getOwner()->uid, UnitySQL::REQUEST_BECOME_PI);
-        $this->SQL->addLog("approved_group", $this->getOwner()->uid);
+        $this->SQL->removeRequest($request, UnitySQL::REQUEST_CREATE_PI_GROUP);
+        $this->SQL->addLog("approved_group", $request);
         if ($send_mail) {
-            $this->MAILER->sendMail($this->getOwner()->getMail(), "group_created");
+            $this->MAILER->sendMail($owner->getMail(), "group_created");
         }
         // having your own group makes you qualified
-        $this->getOwner()->updateIsQualified($send_mail);
+        $owner->updateIsQualified($send_mail);
     }
 
     /**
      * This method is executed when an admin denys the PI group request
      */
-    public function denyGroup(bool $send_mail = true): void
+    public function denyGroup(string $owner_uid, bool $send_mail = true): void
     {
-        $request = $this->SQL->getRequest($this->getOwner()->uid, UnitySQL::REQUEST_BECOME_PI);
-        $this->SQL->removeRequest($this->getOwner()->uid, UnitySQL::REQUEST_BECOME_PI);
+        $request = "$owner_uid:$this->gid";
+        assert($this->SQL->requestExists($request, UnitySQL::REQUEST_CREATE_PI_GROUP));
+        $owner = new UnityUser($owner_uid, $this->LDAP, $this->SQL, $this->MAILER);
+        assert($owner->exists());
+        $this->SQL->removeRequest($owner_uid, UnitySQL::REQUEST_CREATE_PI_GROUP);
         if ($this->exists()) {
             return;
         }
-        $this->SQL->addLog("denied_group", $this->getOwner()->uid);
+        $this->SQL->addLog("denied_group", $owner_uid);
         if ($send_mail) {
-            $this->MAILER->sendMail($this->getOwner()->getMail(), "group_denied");
+            $this->MAILER->sendMail($owner->getMail(), "group_denied");
         }
     }
 
-    public function cancelGroupRequest(bool $send_mail = true): void
+    public function cancelGroupRequest(string $owner_uid, bool $send_mail = true): void
     {
-        if (!$this->SQL->requestExists($this->getOwner()->uid, UnitySQL::REQUEST_BECOME_PI)) {
+        $request = "$owner_uid:$this->gid";
+        if (!$this->SQL->requestExists($request, UnitySQL::REQUEST_CREATE_PI_GROUP)) {
             return;
         }
-        $this->SQL->removeRequest($this->getOwner()->uid, UnitySQL::REQUEST_BECOME_PI);
+        $owner = new UnityUser($owner_uid, $this->LDAP, $this->SQL, $this->MAILER);
+        assert($owner->exists());
+        $this->SQL->removeRequest($request, UnitySQL::REQUEST_CREATE_PI_GROUP);
         if ($send_mail) {
             $this->MAILER->sendMail("pi_approve", "group_request_cancelled", [
-                "uid" => $this->getOwner()->uid,
+                "uid" => $owner_uid,
             ]);
         }
     }
@@ -346,16 +357,15 @@ class UnityGroup extends PosixGroup
         return false;
     }
 
-    private function init(): void
+    private function init($owner_uid): void
     {
-        $owner = $this->getOwner();
         assert(!$this->entry->exists());
         $nextGID = $this->LDAP->getNextPIGIDNumber();
         $this->entry->create([
             "objectclass" => ["unityGroup", "posixGroup", "top"],
             "gidnumber" => strval($nextGID),
-            "memberuid" => [$owner->uid],
-            "owneruid" => $owner->uid,
+            "memberuid" => [$owner_uid],
+            "owneruid" => $owner_uid,
         ]);
         // TODO if we ever make this project based,
         // we need to update the cache here with the memberuid

--- a/resources/lib/UnityLDAP.php
+++ b/resources/lib/UnityLDAP.php
@@ -259,7 +259,7 @@ class UnityLDAP extends LDAPConn
     public function getPIGroupOwnerUIDs(string $filter = self::NON_DISABLED): array
     {
         return array_map(
-            fn($x) => (string) $x["ownerUid"][0],
+            fn($x) => (string) $x["owneruid"][0],
             $this->getPIGroupsAttributes(["ownerUid"], filter: $filter),
         );
     }

--- a/resources/lib/UnityLDAP.php
+++ b/resources/lib/UnityLDAP.php
@@ -237,11 +237,30 @@ class UnityLDAP extends LDAPConn
     }
 
     /** @return string[] */
+    public function getPIGroupGIDsWithOwnerUID(
+        string $uid,
+        string $base_filter = self::NON_DISABLED,
+    ): array {
+        return array_map(
+            fn($x) => $x["cn"][0],
+            $this->pi_groupOU->getChildrenArrayStrict(
+                ["cn"],
+                recursive: false,
+                filter: sprintf(
+                    "(&(owneruid=%s)%s)",
+                    ldap_escape($uid, flags: LDAP_ESCAPE_FILTER),
+                    $base_filter,
+                ),
+            ),
+        );
+    }
+
+    /** @return string[] */
     public function getPIGroupOwnerUIDs(string $filter = self::NON_DISABLED): array
     {
         return array_map(
-            fn($x) => UnityGroup::GID2OwnerUID((string) $x["cn"][0]),
-            $this->getPIGroupsAttributes(["cn"], filter: $filter),
+            fn($x) => (string) $x["ownerUid"][0],
+            $this->getPIGroupsAttributes(["ownerUid"], filter: $filter),
         );
     }
 

--- a/resources/lib/UnitySQL.php
+++ b/resources/lib/UnitySQL.php
@@ -14,7 +14,7 @@ class UnitySQL
     private const string TABLE_AUDIT_LOG = "audit_log";
     private const string TABLE_USER_LAST_LOGINS = "user_last_logins";
     // FIXME this string should be changed to something more intuitive, requires production change
-    public const string REQUEST_BECOME_PI = "admin";
+    public const string REQUEST_CREATE_PI_GROUP = "admin";
     private const int TABLE_AUDIT_LOG_RECIPIENT_MAX_MB_STR_LEN = 768;
 
     private PDO $conn;

--- a/resources/lib/UnitySQL.php
+++ b/resources/lib/UnitySQL.php
@@ -16,6 +16,7 @@ class UnitySQL
     // FIXME this string should be changed to something more intuitive, requires production change
     public const string REQUEST_CREATE_PI_GROUP = "admin";
     private const int TABLE_AUDIT_LOG_RECIPIENT_MAX_MB_STR_LEN = 768;
+    // FIXME the `uid` column should use a more generic name since it can now conatin "uid:gid"
 
     private PDO $conn;
 

--- a/resources/lib/UnityUser.php
+++ b/resources/lib/UnityUser.php
@@ -362,18 +362,27 @@ class UnityUser
         return $this->entry->getAttribute("homedirectory")[0];
     }
 
-    /**
-     * Checks if current user is a PI
-     */
-    public function isPI(): bool
+    /** @return string[] */
+    public function getOwnedPIGroupGIDs(): array
     {
-        return $this->getPIGroup()->exists() && !$this->getPIGroup()->getIsDisabled();
+        return $this->LDAP->getPIGroupGIDsWithOwnerUID($this->uid);
     }
 
-    public function getPIGroup(): UnityGroup
+    /** @return string[] */
+    public function getManagedPIGroupGIDs(): array
+    {
+        return $this->LDAP->getPIGroupGIDsWithManagerUID($this->uid);
+    }
+
+    public function isPI(): bool
+    {
+        return count($this->getOwnedPIGroupGIDs()) > 0;
+    }
+
+    public function getNamesakePIGroup(): UnityGroup
     {
         return new UnityGroup(
-            UnityGroup::ownerUID2GID($this->uid),
+            UnityGroup::ownerUID2NamesakeGID($this->uid),
             $this->LDAP,
             $this->SQL,
             $this->MAILER,
@@ -418,7 +427,7 @@ class UnityUser
         bool $send_mail_pi_group_owner = true,
         bool $send_mail_admin = true,
     ): void {
-        $pi_group = $this->getPIGroup();
+        $pi_group = $this->getNamesakePIGroup();
         if ($pi_group->exists() && !$pi_group->getIsDisabled()) {
             $pi_group->disable($send_mail);
         }

--- a/resources/lib/UnityUser.php
+++ b/resources/lib/UnityUser.php
@@ -376,7 +376,7 @@ class UnityUser
 
     public function isPI(): bool
     {
-        return count($this->getOwnedPIGroupGIDs()) > 0;
+        return $this->getNamesakePIGroup()->exists();
     }
 
     public function getNamesakePIGroup(): UnityGroup

--- a/resources/templates/header.html.twig
+++ b/resources/templates/header.html.twig
@@ -72,9 +72,13 @@
       {{ getRelativeHyperlink('Account Settings', 'panel/account.php')|raw }}
       {{ getRelativeHyperlink('My PIs', 'panel/groups.php')|raw }}
 
-      {% if is_pi %}
-        {{ getRelativeHyperlink('My Users', 'panel/pi.php')|raw }}
-      {% endif %}
+      {% for gid in owned_managed_pi_group_gids %}
+        {% if gid contains uid %}
+          {{ getRelativeHyperlink('My Users', 'panel/pi.php')|raw }}
+        {% else %}
+          {{ getRelativeHyperlink('PI Group ' ~ (gid|e), 'panel/pi.php?gid=' ~ (gid|e))|raw }}
+        {% endif %}
+      {% endfor %}
 
       {% for label in CONFIG['menuitems_secure']['labels'] %}
         <a target="_blank" href="{{ CONFIG['menuitems_secure']['links'][loop.index0] }}">{{ label }}</a>

--- a/resources/templates/header.html.twig
+++ b/resources/templates/header.html.twig
@@ -73,7 +73,7 @@
       {{ getRelativeHyperlink('My PIs', 'panel/groups.php')|raw }}
 
       {% for gid in owned_managed_pi_group_gids %}
-        {% if gid contains uid %}
+        {% if uid in gid %}
           {{ getRelativeHyperlink('My Users', 'panel/pi.php')|raw }}
         {% else %}
           {{ getRelativeHyperlink('PI Group ' ~ (gid|e), 'panel/pi.php?gid=' ~ (gid|e))|raw }}

--- a/resources/templates/header.php
+++ b/resources/templates/header.php
@@ -40,6 +40,6 @@ echo $TWIG->render("header.html.twig", [
     "messages" => UnityHTTPD::getMessages(),
     "viewUser" => $_SESSION["viewUser"] ?? null,
     "user_exists" => $_SESSION["user_exists"] ?? false,
-    "is_pi" => $_SESSION["is_pi"] ?? false,
+    "owned_managed_pi_group_gids" => $_SESSION["owned_managed_pi_group_gids"] ?? [],
     "is_admin" => $_SESSION["is_admin"] ?? false
 ]);

--- a/resources/templates/header.php
+++ b/resources/templates/header.php
@@ -40,6 +40,7 @@ echo $TWIG->render("header.html.twig", [
     "messages" => UnityHTTPD::getMessages(),
     "viewUser" => $_SESSION["viewUser"] ?? null,
     "user_exists" => $_SESSION["user_exists"] ?? false,
+    "uid" => $_SESSION["SSO"]["user"],
     "owned_managed_pi_group_gids" => $_SESSION["owned_managed_pi_group_gids"] ?? [],
     "is_admin" => $_SESSION["is_admin"] ?? false
 ]);

--- a/resources/templates/header.php
+++ b/resources/templates/header.php
@@ -40,7 +40,7 @@ echo $TWIG->render("header.html.twig", [
     "messages" => UnityHTTPD::getMessages(),
     "viewUser" => $_SESSION["viewUser"] ?? null,
     "user_exists" => $_SESSION["user_exists"] ?? false,
-    "uid" => $_SESSION["SSO"]["user"],
+    "uid" => $_SESSION["SSO"]["user"] ?? null,
     "owned_managed_pi_group_gids" => $_SESSION["owned_managed_pi_group_gids"] ?? [],
     "is_admin" => $_SESSION["is_admin"] ?? false
 ]);

--- a/test/functional/ExpiryWorkerTest.php
+++ b/test/functional/ExpiryWorkerTest.php
@@ -59,7 +59,7 @@ class ExpiryWorkerTest extends UnityWebPortalTestCase
         $this->assertFalse($USER->getFlag(UserFlag::IDLELOCKED));
         $this->assertFalse($USER->getFlag(UserFlag::DISABLED));
         if ($is_pi) {
-            $this->assertFalse($USER->getPIGroup()->getIsDisabled());
+            $this->assertFalse($USER->getNamesakePIGroup()->getIsDisabled());
         }
         // see deployment/overrides/phpunit/config/config.ini
         $this->assertEquals(CONFIG["expiry"]["idlelock_warning_days"], [2, 3]);
@@ -122,7 +122,7 @@ class ExpiryWorkerTest extends UnityWebPortalTestCase
             $this->assertTrue($USER->getFlag(UserFlag::DISABLED));
             $this->assertEmpty($USER->getSSHKeys());
             if ($is_pi) {
-                $this->assertTrue($USER->getPIGroup()->getIsDisabled());
+                $this->assertTrue($USER->getNamesakePIGroup()->getIsDisabled());
             }
             // 9 ///////////////////////////////////////////////////////////////////////////////////
             $output = $this->runExpiryWorker(idle_days: 9);
@@ -132,8 +132,8 @@ class ExpiryWorkerTest extends UnityWebPortalTestCase
             if ($USER->getFlag(UserFlag::DISABLED)) {
                 $USER->reEnable();
             }
-            if ($is_pi && $USER->getPIGroup()->getIsDisabled()) {
-                callPrivateMethod($USER->getPIGroup(), "reenable");
+            if ($is_pi && $USER->getNamesakePIGroup()->getIsDisabled()) {
+                callPrivateMethod($USER->getNamesakePIGroup(), "reenable");
             }
             callPrivateMethod($USER, "setSSHKeys", $ssh_keys_before);
         }
@@ -214,7 +214,7 @@ class ExpiryWorkerTest extends UnityWebPortalTestCase
         $member = $USER;
         $this->switchUser("EmptyPIGroupOwner");
         $owner = $USER;
-        $pi_group = $USER->getPIGroup();
+        $pi_group = $USER->getNamesakePIGroup();
         try {
             $owner->setFlag(UserFlag::IDLELOCKED, true);
             $pi_group->newUserRequest($member, false);
@@ -239,7 +239,7 @@ class ExpiryWorkerTest extends UnityWebPortalTestCase
                         "idle_days" => 7,
                         "expiration_date" => "1970/01/10",
                         "is_final_warning" => true,
-                        "pi_group_gid" => $owner->getPIGroup()->gid,
+                        "pi_group_gid" => $owner->getNamesakePIGroup()->gid,
                     ]),
                     "user_expiry_disable_warning_member",
                     '["' . $member->getMail() . '"]',
@@ -248,7 +248,7 @@ class ExpiryWorkerTest extends UnityWebPortalTestCase
                         "idle_days" => 7,
                         "expiration_date" => "1970/01/10",
                         "is_final_warning" => true,
-                        "pi_group_gid" => $owner->getPIGroup()->gid,
+                        "pi_group_gid" => $owner->getNamesakePIGroup()->gid,
                     ]),
                 ),
                 $output,
@@ -266,7 +266,7 @@ class ExpiryWorkerTest extends UnityWebPortalTestCase
         global $USER, $LDAP, $SQL, $MAILER;
         $this->switchUser("EmptyPIGroupOwner");
         $owner = $USER;
-        $pi_group = $USER->getPIGroup();
+        $pi_group = $USER->getNamesakePIGroup();
         $this->assertEmpty($pi_group->getManagerUIDs());
         $manager_uid = self::$NICKNAME2UID["Admin"];
         $manager = new UnityUser($manager_uid, $LDAP, $SQL, $MAILER);

--- a/test/functional/ExpiryWorkerTest.php
+++ b/test/functional/ExpiryWorkerTest.php
@@ -291,10 +291,7 @@ class ExpiryWorkerTest extends UnityWebPortalTestCase
                     "idle-locking user '%s'\nsending %s email to %s with data %s",
                     $member->uid,
                     "group_user_idlelocked_owner",
-                    _json_encode([
-                        $pi_group->addPlusAddressToMail($manager->getMail()),
-                        $owner->getMail(),
-                    ]),
+                    _json_encode([$manager->getMail(), $owner->getMail()]),
                     _json_encode([
                         "group" => $pi_group->gid,
                         "user" => $member->uid,

--- a/test/functional/PIBecomeRequestTest.php
+++ b/test/functional/PIBecomeRequestTest.php
@@ -79,7 +79,7 @@ class PIBecomeRequestTest extends UnityWebPortalTestCase
     {
         global $USER, $SSO, $LDAP, $SQL, $MAILER;
         $this->switchUser("Blank");
-        $pi_group = $USER->getPIGroup();
+        $pi_group = $USER->getNamesakePIGroup();
         try {
             $this->requestGroupCreation();
             $this->assertRequestedPIGroup(true);
@@ -120,7 +120,7 @@ class PIBecomeRequestTest extends UnityWebPortalTestCase
         $this->switchUser("ReenabledOwnerOfDisabledPIGroup");
         $this->assertFalse($USER->isPI());
         $user = $USER;
-        $pi_group = $USER->getPIGroup();
+        $pi_group = $USER->getNamesakePIGroup();
         $approve_uid = $USER->uid;
         try {
             $this->requestGroupCreation();
@@ -141,7 +141,7 @@ class PIBecomeRequestTest extends UnityWebPortalTestCase
     {
         global $USER, $LDAP, $SQL, $MAILER;
         $this->switchUser("Blank");
-        $piGroup = $USER->getPIGroup();
+        $piGroup = $USER->getNamesakePIGroup();
         $this->assertFalse($piGroup->exists());
         $this->assertFalse($SQL->requestExists($USER->uid, UnitySQL::REQUEST_BECOME_PI));
         $piGroup->requestGroup();

--- a/test/functional/PIBecomeRequestTest.php
+++ b/test/functional/PIBecomeRequestTest.php
@@ -69,8 +69,8 @@ class PIBecomeRequestTest extends UnityWebPortalTestCase
             );
             $this->assertNumberPiBecomeRequests(1);
         } finally {
-            if ($SQL->requestExists($USER, UnitySQL::REQUEST_BECOME_PI)) {
-                $SQL->removeRequest($USER->uid, UnitySQL::REQUEST_BECOME_PI);
+            if ($SQL->requestExists($USER, UnitySQL::REQUEST_CREATE_PI_GROUP)) {
+                $SQL->removeRequest($USER->uid, UnitySQL::REQUEST_CREATE_PI_GROUP);
             }
         }
     }
@@ -143,10 +143,10 @@ class PIBecomeRequestTest extends UnityWebPortalTestCase
         $this->switchUser("Blank");
         $piGroup = $USER->getNamesakePIGroup();
         $this->assertFalse($piGroup->exists());
-        $this->assertFalse($SQL->requestExists($USER->uid, UnitySQL::REQUEST_BECOME_PI));
-        $piGroup->requestGroup();
+        $this->assertFalse($SQL->requestExists($USER->uid, UnitySQL::REQUEST_CREATE_PI_GROUP));
+        $piGroup->requestGroup($USER->uid);
         try {
-            $this->assertTrue($SQL->requestExists($USER->uid, UnitySQL::REQUEST_BECOME_PI));
+            $this->assertTrue($SQL->requestExists($USER->uid, UnitySQL::REQUEST_CREATE_PI_GROUP));
             $this->switchUser("Admin");
             $this->http_post(__DIR__ . "/../../webroot/admin/pi-mgmt.php", [
                 "form_type" => "req",
@@ -155,10 +155,10 @@ class PIBecomeRequestTest extends UnityWebPortalTestCase
             ]);
             $this->switchBackUser();
             $this->assertFalse($piGroup->exists());
-            $this->assertFalse($SQL->requestExists($USER->uid, UnitySQL::REQUEST_BECOME_PI));
+            $this->assertFalse($SQL->requestExists($USER->uid, UnitySQL::REQUEST_CREATE_PI_GROUP));
         } finally {
-            if ($SQL->requestExists($USER->uid, UnitySQL::REQUEST_BECOME_PI)) {
-                $SQL->removeRequest($USER->uid, UnitySQL::REQUEST_BECOME_PI);
+            if ($SQL->requestExists($USER->uid, UnitySQL::REQUEST_CREATE_PI_GROUP)) {
+                $SQL->removeRequest($USER->uid, UnitySQL::REQUEST_CREATE_PI_GROUP);
             }
         }
     }

--- a/test/functional/PIBecomeRequestTest.php
+++ b/test/functional/PIBecomeRequestTest.php
@@ -4,6 +4,7 @@ use UnityWebPortal\lib\UnityHTTPDMessageLevel;
 use UnityWebPortal\lib\UnitySQL;
 use UnityWebPortal\lib\UserFlag;
 use UnityWebPortal\lib\UnityHTTPD;
+use UnityWebPortal\lib\UnityGroup;
 
 class PIBecomeRequestTest extends UnityWebPortalTestCase
 {
@@ -27,11 +28,12 @@ class PIBecomeRequestTest extends UnityWebPortalTestCase
         ]);
     }
 
-    private function approveGroup($uid)
+    private function approveGroup($uid, $gid)
     {
         $this->http_post(__DIR__ . "/../../webroot/admin/pi-mgmt.php", [
             "form_type" => "req",
             "action" => "Approve",
+            "pi" => $gid,
             "uid" => $uid,
         ]);
     }
@@ -40,6 +42,8 @@ class PIBecomeRequestTest extends UnityWebPortalTestCase
     {
         global $USER, $SQL;
         $this->switchUser("Blank");
+        $gid = UnityGroup::ownerUID2NamesakeGID($USER->uid);
+        $request = "$USER->uid:$gid";
         $this->assertNumberPiBecomeRequests(0);
         try {
             $this->http_post(__DIR__ . "/../../webroot/panel/account.php", [
@@ -69,8 +73,8 @@ class PIBecomeRequestTest extends UnityWebPortalTestCase
             );
             $this->assertNumberPiBecomeRequests(1);
         } finally {
-            if ($SQL->requestExists($USER, UnitySQL::REQUEST_CREATE_PI_GROUP)) {
-                $SQL->removeRequest($USER->uid, UnitySQL::REQUEST_CREATE_PI_GROUP);
+            if ($SQL->requestExists($request, UnitySQL::REQUEST_CREATE_PI_GROUP)) {
+                $SQL->removeRequest($request, UnitySQL::REQUEST_CREATE_PI_GROUP);
             }
         }
     }
@@ -97,7 +101,7 @@ class PIBecomeRequestTest extends UnityWebPortalTestCase
 
             $approve_uid = $SSO["user"];
             $this->switchUser("Admin");
-            $this->approveGroup($approve_uid);
+            $this->approveGroup($approve_uid, $pi_group->gid);
             $this->switchUser("Blank", validate: false);
 
             $this->assertRequestedPIGroup(false);
@@ -126,7 +130,7 @@ class PIBecomeRequestTest extends UnityWebPortalTestCase
             $this->requestGroupCreation();
             $this->assertRequestedPIGroup(true);
             $this->switchUser("Admin");
-            $this->approveGroup($approve_uid);
+            $this->approveGroup($approve_uid, $pi_group->gid);
             $this->assertTrue($user->isPI());
         } finally {
             if ($pi_group->memberUIDExists($approve_uid)) {
@@ -141,24 +145,26 @@ class PIBecomeRequestTest extends UnityWebPortalTestCase
     {
         global $USER, $LDAP, $SQL, $MAILER;
         $this->switchUser("Blank");
+        $uid = $USER->uid;
         $piGroup = $USER->getNamesakePIGroup();
         $this->assertFalse($piGroup->exists());
-        $this->assertFalse($SQL->requestExists($USER->uid, UnitySQL::REQUEST_CREATE_PI_GROUP));
+        $request = "$USER->uid:$piGroup->gid";
+        $this->assertFalse($SQL->requestExists($request, UnitySQL::REQUEST_CREATE_PI_GROUP));
         $piGroup->requestGroup($USER->uid);
         try {
-            $this->assertTrue($SQL->requestExists($USER->uid, UnitySQL::REQUEST_CREATE_PI_GROUP));
+            $this->assertTrue($SQL->requestExists($request, UnitySQL::REQUEST_CREATE_PI_GROUP));
             $this->switchUser("Admin");
             $this->http_post(__DIR__ . "/../../webroot/admin/pi-mgmt.php", [
                 "form_type" => "req",
                 "action" => "Deny",
-                "uid" => $piGroup->getOwner()->uid,
+                "uid" => $uid,
+                "pi" => $piGroup->gid,
             ]);
-            $this->switchBackUser();
             $this->assertFalse($piGroup->exists());
-            $this->assertFalse($SQL->requestExists($USER->uid, UnitySQL::REQUEST_CREATE_PI_GROUP));
+            $this->assertFalse($SQL->requestExists($request, UnitySQL::REQUEST_CREATE_PI_GROUP));
         } finally {
-            if ($SQL->requestExists($USER->uid, UnitySQL::REQUEST_CREATE_PI_GROUP)) {
-                $SQL->removeRequest($USER->uid, UnitySQL::REQUEST_CREATE_PI_GROUP);
+            if ($SQL->requestExists($request, UnitySQL::REQUEST_CREATE_PI_GROUP)) {
+                $SQL->removeRequest($request, UnitySQL::REQUEST_CREATE_PI_GROUP);
             }
         }
     }

--- a/test/functional/PIDisableTest.php
+++ b/test/functional/PIDisableTest.php
@@ -9,7 +9,7 @@ class PIDisableTest extends UnityWebPortalTestCase
     {
         global $USER, $LDAP;
         $this->switchUser("EmptyPIGroupOwner");
-        $pi_group = $USER->getPIGroup();
+        $pi_group = $USER->getNamesakePIGroup();
         $memberuids_before = $pi_group->getMemberUIDs();
         $this->assertFalse($pi_group->getIsDisabled());
         $this->assertNotEmpty($pi_group->getMemberUIDs());
@@ -36,7 +36,7 @@ class PIDisableTest extends UnityWebPortalTestCase
     {
         global $USER, $LDAP;
         $this->switchUser("EmptyPIGroupOwner");
-        $pi_group = $USER->getPIGroup();
+        $pi_group = $USER->getNamesakePIGroup();
         $memberuids_before = $pi_group->getMemberUIDs();
         $this->assertFalse($pi_group->getIsDisabled());
         $this->assertNotEmpty($pi_group->getMemberUIDs());
@@ -85,7 +85,7 @@ class PIDisableTest extends UnityWebPortalTestCase
         $new_user = $USER;
         $this->assertFalse($new_user->getFlag(UserFlag::QUALIFIED));
         $this->switchUser("EmptyPIGroupOwner");
-        $pi_group = $USER->getPIGroup();
+        $pi_group = $USER->getNamesakePIGroup();
         $memberuids_before = $pi_group->getMemberUIDs();
         try {
             $pi_group->newUserRequest($new_user);
@@ -113,7 +113,7 @@ class PIDisableTest extends UnityWebPortalTestCase
         $new_user = $USER;
         $this->assertFalse($new_user->getFlag(UserFlag::QUALIFIED));
         $this->switchUser("EmptyPIGroupOwner");
-        $pi_group = $USER->getPIGroup();
+        $pi_group = $USER->getNamesakePIGroup();
         $memberuids_before = $pi_group->getMemberUIDs();
         try {
             $pi_group->newUserRequest($new_user);
@@ -141,7 +141,7 @@ class PIDisableTest extends UnityWebPortalTestCase
     {
         global $USER, $LDAP;
         $this->switchUser("NormalPI");
-        $pi_group = $USER->getPIGroup();
+        $pi_group = $USER->getNamesakePIGroup();
         $entry = $LDAP->getPIGroupEntry($pi_group->gid);
         $this->assertEquals([], $entry->getAttribute("isDisabled"));
         try {
@@ -162,7 +162,7 @@ class PIDisableTest extends UnityWebPortalTestCase
     {
         global $USER, $LDAP;
         $this->switchUser("NormalPI");
-        $pi_group = $USER->getPIGroup();
+        $pi_group = $USER->getNamesakePIGroup();
         $entry = $LDAP->getPIGroupEntry($pi_group->gid);
         $this->assertEquals([], $entry->getAttribute("isDisabled"));
         $this->switchUser("Admin");

--- a/test/functional/PIMemberRequestTest.php
+++ b/test/functional/PIMemberRequestTest.php
@@ -32,7 +32,7 @@ class PIMemberRequestTest extends UnityWebPortalTestCase
     private function approveUserByPI(string $uid, string $gid)
     {
         global $USER;
-        assert($USER->getPIGroup()->gid === $gid, "signed in user must be the group owner");
+        assert($USER->getNamesakePIGroup()->gid === $gid, "signed in user must be the group owner");
         $this->http_post(__DIR__ . "/../../webroot/panel/pi.php", [
             "form_type" => "userReq",
             "action" => "Approve",
@@ -67,7 +67,7 @@ class PIMemberRequestTest extends UnityWebPortalTestCase
     private function denyRequestByAdmin(string $uid)
     {
         global $USER;
-        $gid = $USER->getPIGroup()->gid;
+        $gid = $USER->getNamesakePIGroup()->gid;
         $this->switchUser("Admin");
         try {
             $this->http_post(__DIR__ . "/../../webroot/admin/pi-mgmt.php", [
@@ -85,7 +85,7 @@ class PIMemberRequestTest extends UnityWebPortalTestCase
     {
         global $USER, $SQL;
         $this->switchUser("EmptyPIGroupOwner");
-        $pi_group = $USER->getPIGroup();
+        $pi_group = $USER->getNamesakePIGroup();
         $this->switchUser("Blank");
         try {
             $this->requestMembership($pi_group->gid);
@@ -103,7 +103,7 @@ class PIMemberRequestTest extends UnityWebPortalTestCase
     {
         global $USER, $SQL;
         $this->switchUser("EmptyPIGroupOwner");
-        $pi_group = $USER->getPIGroup();
+        $pi_group = $USER->getNamesakePIGroup();
         $this->switchUser("Blank");
         try {
             UnityHTTPD::clearMessages();
@@ -125,7 +125,7 @@ class PIMemberRequestTest extends UnityWebPortalTestCase
     {
         global $USER, $SQL;
         $this->switchUser("EmptyPIGroupOwner");
-        $pi_group = $USER->getPIGroup();
+        $pi_group = $USER->getNamesakePIGroup();
         $this->switchUser("Blank");
         $this->assertNumberRequests(0);
         try {
@@ -180,7 +180,7 @@ class PIMemberRequestTest extends UnityWebPortalTestCase
         $this->switchUser("Blank");
         $uid = $USER->uid;
         $this->switchUser("EmptyPIGroupOwner");
-        $piGroup = $USER->getPIGroup();
+        $piGroup = $USER->getNamesakePIGroup();
         try {
             $this->expectException(Exception::class); // FIXME more specific exception type
             $this->$methodName($uid, $piGroup->gid);
@@ -196,7 +196,7 @@ class PIMemberRequestTest extends UnityWebPortalTestCase
         global $USER, $SSO, $LDAP, $SQL, $MAILER;
         $this->switchUser("EmptyPIGroupOwner");
         $pi_uid = $USER->uid;
-        $pi_group = $USER->getPIGroup();
+        $pi_group = $USER->getNamesakePIGroup();
         $gid = $pi_group->gid;
         $this->switchUser("Blank");
         try {
@@ -234,7 +234,7 @@ class PIMemberRequestTest extends UnityWebPortalTestCase
         $requestedUser = $USER;
         $this->switchUser("EmptyPIGroupOwner");
         $pi = $USER;
-        $piGroup = $USER->getPIGroup();
+        $piGroup = $USER->getNamesakePIGroup();
         $this->assertEmpty($piGroup->getRequests());
         $this->assertEqualsCanonicalizing([$pi->uid], $piGroup->getMemberUIDs());
         try {

--- a/test/functional/PIRemoveUserTest.php
+++ b/test/functional/PIRemoveUserTest.php
@@ -11,7 +11,7 @@ class PIRemoveUserTest extends UnityWebPortalTestCase
     private function removeUserByPI(string $uid, string $gid)
     {
         global $USER;
-        assert($USER->getPIGroup()->gid === $gid, "signed in user must be the group owner");
+        assert($USER->getNamesakePIGroup()->gid === $gid, "signed in user must be the group owner");
         $this->http_post(__DIR__ . "/../../webroot/panel/pi.php", [
             "form_type" => "remUser",
             "uid" => $uid,
@@ -45,7 +45,7 @@ class PIRemoveUserTest extends UnityWebPortalTestCase
         $this->switchUser("NormalPI");
         $pi = $USER;
         $piUid = $USER->uid;
-        $piGroup = $USER->getPIGroup();
+        $piGroup = $USER->getNamesakePIGroup();
         $memberUIDs = $piGroup->getMemberUIDs();
         // the ordering of the uids in getGroupMemberUIDs is different each time
         // use a linear search to find a user who is not the PI
@@ -78,7 +78,7 @@ class PIRemoveUserTest extends UnityWebPortalTestCase
         global $USER, $LDAP, $SQL, $MAILER;
         $this->switchUser("NormalPI");
         $pi = $USER;
-        $piGroup = $USER->getPIGroup();
+        $piGroup = $USER->getNamesakePIGroup();
         $this->expectException(Exception::class);
         try {
             $this->$methodName($piGroup->getOwner()->uid, $piGroup->gid);
@@ -95,7 +95,7 @@ class PIRemoveUserTest extends UnityWebPortalTestCase
     {
         global $USER;
         $this->switchUser("CourseGroupOwner");
-        $group = $USER->getPIGroup();
+        $group = $USER->getNamesakePIGroup();
         $manager_uids = $group->getManagerUIDs();
         $this->assertNotEmpty($manager_uids);
         $manager_uid = $manager_uids[0];

--- a/test/functional/PIRemoveUserTest.php
+++ b/test/functional/PIRemoveUserTest.php
@@ -93,9 +93,10 @@ class PIRemoveUserTest extends UnityWebPortalTestCase
 
     public function testRemoveMemberAlsoRemovesManager()
     {
-        global $USER;
+        global $USER, $LDAP, $SQL, $MAILER;
         $this->switchUser("CourseGroupOwner");
-        $group = $USER->getNamesakePIGroup();
+        $gid = $LDAP->getPIGroupGIDsWithOwnerUID($USER->uid)[0];
+        $group = new UnityGroup($gid, $LDAP, $SQL, $MAILER);
         $manager_uids = $group->getManagerUIDs();
         $this->assertNotEmpty($manager_uids);
         $manager_uid = $manager_uids[0];

--- a/test/functional/PageLoadTest.php
+++ b/test/functional/PageLoadTest.php
@@ -89,7 +89,7 @@ class PageLoadTest extends UnityWebPortalTestCase
     {
         global $USER;
         $this->switchUser("EmptyPIGroupOwner");
-        $gid = $USER->getPIGroup()->gid;
+        $gid = $USER->getNamesakePIGroup()->gid;
         $this->switchUser("Blank");
         $output = $this->http_get(
             __DIR__ . "/../../webroot/panel/pi.php",

--- a/test/functional/WorkerRemoveUsersFromGroupTest.php
+++ b/test/functional/WorkerRemoveUsersFromGroupTest.php
@@ -10,7 +10,7 @@ class WorkerRemoveUsersFromGroupTest extends UnityWebPortalTestCase
         global $USER, $LDAP, $SQL, $MAILER;
         $this->switchUser("EmptyPIGroupOwner");
         $pi = $USER;
-        $pi_group = $USER->getPIGroup();
+        $pi_group = $USER->getNamesakePIGroup();
         $this->assertTrue($pi->isPI());
         $this->assertEqualsCanonicalizing([$pi->uid], $pi_group->getMemberUIDs());
         $this->assertEqualsCanonicalizing([$pi->uid], $pi_group->getMemberUIDs());
@@ -33,7 +33,7 @@ class WorkerRemoveUsersFromGroupTest extends UnityWebPortalTestCase
             print implode("\n", $output);
             $this->switchUser("EmptyPIGroupOwner", validate: false);
             $pi = $USER;
-            $pi_group = $USER->getPIGroup();
+            $pi_group = $USER->getNamesakePIGroup();
             $this->assertEqualsCanonicalizing($expected_new_uids, $pi_group->getMemberUIDs());
             $this->assertEqualsCanonicalizing($expected_new_uids, $pi_group->getMemberUIDs());
         } finally {
@@ -77,7 +77,7 @@ class WorkerRemoveUsersFromGroupTest extends UnityWebPortalTestCase
     {
         global $USER;
         $this->switchUser("EmptyPIGroupOwner");
-        $pi_group = $USER->getPIGroup();
+        $pi_group = $USER->getNamesakePIGroup();
         $members_before = $pi_group->getMemberUIDs();
         $remove_uids_file = writeLinesToTmpFile(["foo", "bar"]);
         $remove_uids_file_path = getPathFromFileHandle($remove_uids_file);

--- a/test/functional/WorkerUnityCourseTest.php
+++ b/test/functional/WorkerUnityCourseTest.php
@@ -2,29 +2,22 @@
 
 class WorkerUnityCourseTest extends UnityWebPortalTestCase
 {
-    private static string $course_owner_uid = "cs124_org1_test";
+    private static string $course_owner_uid = "user2_org1_test";
     private static string $course_gid = "pi_cs124_org1_test";
-    private static array $course_owner_name = ["cs124", "Fall 2025"];
-    private static string $manager_uid = "user2_org1_test";
-    private static string $manager_mail = "user2@org1.test";
-    private static string $courseOwnerMail = "user2+cs124@org1.test";
+    private static array $course_info = ["cs124", "Fall 2025"];
 
     public function testCreateCourse()
     {
         global $LDAP, $USER;
         $this->switchUser("Blank");
-        $this->assertEquals(self::$manager_uid, $USER->uid);
-        $this->assertEquals(self::$manager_mail, $USER->getMail());
-        $manager = $USER;
+        $this->assertEquals(self::$course_owner_uid, $USER->uid);
         $pi_group_entry = $LDAP->getPIGroupEntry(self::$course_gid);
-        $owner_user_entry = $LDAP->getUserEntry(self::$course_owner_uid);
         $this->assertFalse($pi_group_entry->exists());
-        $this->assertFalse($owner_user_entry->exists());
         $stdin_file = writeLinesToTmpFile([
-            self::$course_owner_name[0],
-            self::$course_owner_name[1],
+            self::$course_info[0],
+            self::$course_info[1],
+            self::$course_gid,
             self::$course_owner_uid,
-            self::$manager_uid,
         ]);
         $stdin_file_path = getPathFromFileHandle($stdin_file);
         try {
@@ -34,21 +27,21 @@ class WorkerUnityCourseTest extends UnityWebPortalTestCase
             unset($GLOBALS["ldapconn"]);
             $this->switchUser("Admin");
             $pi_group_entry = $LDAP->getPIGroupEntry(self::$course_gid);
-            $owner_user_entry = $LDAP->getUserEntry(self::$course_owner_uid);
             $this->assertTrue($pi_group_entry->exists());
-            $this->assertTrue($owner_user_entry->exists());
-            $this->assertEquals(self::$courseOwnerMail, $owner_user_entry->getAttribute("mail")[0]);
             $this->assertEqualsCanonicalizing(
-                [self::$course_owner_uid, $manager->uid],
+                [self::$course_owner_uid],
                 $pi_group_entry->getAttribute("memberuid"),
             );
             $this->assertEqualsCanonicalizing(
-                [$manager->uid],
-                $pi_group_entry->getAttribute("manageruid"),
+                [self::$course_owner_uid],
+                $pi_group_entry->getAttribute("owneruid"),
+            );
+            $this->assertEqualsCanonicalizing(
+                [self::$course_info[0] . " " . self::$course_info[1]],
+                $pi_group_entry->getAttribute("description"),
             );
         } finally {
             ensurePIGroupDoesNotExist(self::$course_gid);
-            ensureUserDoesNotExist(self::$course_owner_uid);
             unlink($stdin_file_path);
         }
     }

--- a/test/functional/WorkerUnityCourseTest.php
+++ b/test/functional/WorkerUnityCourseTest.php
@@ -3,6 +3,7 @@
 class WorkerUnityCourseTest extends UnityWebPortalTestCase
 {
     private static string $course_owner_uid = "user2_org1_test";
+    private static string $course_manager_uid = "user3_org1_test";
     private static string $course_gid = "pi_cs124_org1_test";
     private static array $course_info = ["cs124", "Fall 2025"];
 
@@ -18,6 +19,7 @@ class WorkerUnityCourseTest extends UnityWebPortalTestCase
             self::$course_info[1],
             self::$course_gid,
             self::$course_owner_uid,
+            self::$course_manager_uid,
         ]);
         $stdin_file_path = getPathFromFileHandle($stdin_file);
         try {
@@ -29,8 +31,12 @@ class WorkerUnityCourseTest extends UnityWebPortalTestCase
             $pi_group_entry = $LDAP->getPIGroupEntry(self::$course_gid);
             $this->assertTrue($pi_group_entry->exists());
             $this->assertEqualsCanonicalizing(
-                [self::$course_owner_uid],
+                [self::$course_owner_uid, self::$course_manager_uid],
                 $pi_group_entry->getAttribute("memberuid"),
+            );
+            $this->assertEqualsCanonicalizing(
+                [self::$course_manager_uid],
+                $pi_group_entry->getAttribute("manageruid"),
             );
             $this->assertEqualsCanonicalizing(
                 [self::$course_owner_uid],

--- a/test/functional/WorkerUpdateQualifiedUsersGroupTest.php
+++ b/test/functional/WorkerUpdateQualifiedUsersGroupTest.php
@@ -9,7 +9,7 @@ class WorkerUpdateQualifiedUsersGroupTest extends UnityWebPortalTestCase
     {
         global $USER, $LDAP, $SQL, $MAILER;
         $this->switchUser("EmptyPIGroupOwner");
-        $pi_group = $USER->getPIGroup();
+        $pi_group = $USER->getNamesakePIGroup();
         $this->switchUser("Blank");
         $user = $USER;
         $expectedOutput = [

--- a/test/phpunit-bootstrap.php
+++ b/test/phpunit-bootstrap.php
@@ -202,6 +202,12 @@ function accessPrivateVariable($obj, string $name)
     return $property->getValue($obj);
 }
 
+function accessPrivateConst($obj, string $name)
+{
+    $class = new \ReflectionClass($obj);
+    return $class->getConstant($name);
+}
+
 class UnityWebPortalTestCase extends TestCase
 {
     private ?string $last_user_nickname = null;
@@ -432,22 +438,25 @@ class UnityWebPortalTestCase extends TestCase
     public function assertRequestedPIGroup(bool $expected)
     {
         global $USER, $SQL;
+        $gid = UnityGroup::ownerUID2NamesakeGID($USER->uid);
+        $request = "$USER->uid:$gid";
         $this->assertEquals(
             $expected,
-            $SQL->requestExists($USER->uid, UnitySQL::REQUEST_CREATE_PI_GROUP),
+            $SQL->requestExists($request, UnitySQL::REQUEST_CREATE_PI_GROUP),
         );
     }
 
     public function getNumberPiBecomeRequests()
     {
         global $USER, $SQL;
-        // FIXME table name, "admin" are public constants in UnitySQL
-        // FIXME "admin" should be something else
+        $gid = UnityGroup::ownerUID2NamesakeGID($USER->uid);
+        $request = "$USER->uid:$gid";
+        $table = accessPrivateConst($SQL, "TABLE_REQS");
+        $request_for = accessPrivateConst($SQL, "REQUEST_CREATE_PI_GROUP");
         $stmt = $SQL
             ->getConn()
-            ->prepare("SELECT * FROM requests WHERE uid=:uid and request_for='admin'");
-        $uid = $USER->uid;
-        $stmt->bindParam(":uid", $uid);
+            ->prepare("SELECT * FROM $table WHERE uid=:request and request_for='$request_for'");
+        $stmt->bindParam(":request", $request);
         $stmt->execute();
         return count($stmt->fetchAll());
     }
@@ -455,10 +464,12 @@ class UnityWebPortalTestCase extends TestCase
     public function assertNumberPiBecomeRequests(int $x)
     {
         global $USER, $SQL;
+        $gid = UnityGroup::ownerUID2NamesakeGID($USER->uid);
+        $request = "$USER->uid:$gid";
         if ($x == 0) {
-            $this->assertFalse($SQL->requestExists($USER->uid, UnitySQL::REQUEST_CREATE_PI_GROUP));
+            $this->assertFalse($SQL->requestExists($request, UnitySQL::REQUEST_CREATE_PI_GROUP));
         } elseif ($x > 0) {
-            $this->assertTrue($SQL->requestExists($USER->uid, UnitySQL::REQUEST_CREATE_PI_GROUP));
+            $this->assertTrue($SQL->requestExists($request, UnitySQL::REQUEST_CREATE_PI_GROUP));
         } else {
             throw new RuntimeException("x must not be negative");
         }

--- a/test/phpunit-bootstrap.php
+++ b/test/phpunit-bootstrap.php
@@ -282,8 +282,8 @@ class UnityWebPortalTestCase extends TestCase
                 $this->assertTrue($LDAP->getOrgGroupEntry($USER->getOrg())->exists());
                 break;
             case "CourseGroupOwner":
-                $this->assertTrue($USER->getPIGroup()->exists());
-                $this->assertNotEmpty($USER->getPIGroup()->getManagerUIDs());
+                $this->assertTrue($USER->getNamesakePIGroup()->exists());
+                $this->assertNotEmpty($USER->getNamesakePIGroup()->getManagerUIDs());
                 break;
             case "CourseGroupManager":
                 $this->assertNotEmpty($LDAP->getPIGroupGIDsWithManagerUID($USER->uid));
@@ -295,7 +295,7 @@ class UnityWebPortalTestCase extends TestCase
                 break;
             case "EmptyPIGroupOwner":
                 $this->assertTrue($USER->isPI());
-                $pi_group = $USER->getPIGroup();
+                $pi_group = $USER->getNamesakePIGroup();
                 $this->assertEqualsCanonicalizing([$USER->uid], $pi_group->getMemberUIDs());
                 $this->assertEmpty($pi_group->getRequests());
                 break;
@@ -304,12 +304,12 @@ class UnityWebPortalTestCase extends TestCase
                 break;
             case "DisabledOwnerOfDisabledPIGroup":
                 $this->assertTrue($USER->getFlag(UserFlag::DISABLED));
-                $this->assertTrue($USER->getPIGroup()->exists());
-                $this->assertTrue($USER->getPIGroup()->getIsDisabled());
+                $this->assertTrue($USER->getNamesakePIGroup()->exists());
+                $this->assertTrue($USER->getNamesakePIGroup()->getIsDisabled());
                 break;
             case "DisabledNotPI":
                 $this->assertTrue($USER->getFlag(UserFlag::DISABLED));
-                $this->assertFalse($USER->getPIGroup()->exists());
+                $this->assertFalse($USER->getNamesakePIGroup()->exists());
                 break;
             case "DisabledPIGroup_user9_org3_test_Manager":
                 $pi_group_entry = $LDAP->getPIGroupEntry("pi_user9_org3_test");
@@ -320,8 +320,8 @@ class UnityWebPortalTestCase extends TestCase
                 $this->assertTrue($USER->exists());
                 $this->assertFalse($USER->getFlag(UserFlag::DISABLED));
                 $this->assertFalse($USER->isPI());
-                $this->assertTrue($USER->getPIGroup()->exists());
-                $this->assertTrue($USER->getPIGroup()->getIsDisabled());
+                $this->assertTrue($USER->getNamesakePIGroup()->exists());
+                $this->assertTrue($USER->getNamesakePIGroup()->getIsDisabled());
                 break;
             case "HasNoSshKeys":
                 $this->assertEmpty($USER->getSSHKeys());
@@ -333,7 +333,7 @@ class UnityWebPortalTestCase extends TestCase
                 break;
             case "ImmortalNotPI":
                 $this->assertTrue($USER->getFlag(UserFlag::IMMORTAL));
-                $this->assertFalse($USER->getPIGroup()->exists());
+                $this->assertFalse($USER->getNamesakePIGroup()->exists());
                 break;
             case "Locked":
                 $this->assertTrue($USER->getFlag(UserFlag::LOCKED));
@@ -358,7 +358,10 @@ class UnityWebPortalTestCase extends TestCase
                 break;
             case "NormalPI":
                 $this->assertTrue($USER->isPI());
-                $this->assertGreaterThanOrEqual(2, count($USER->getPIGroup()->getMemberUIDs()));
+                $this->assertGreaterThanOrEqual(
+                    2,
+                    count($USER->getNamesakePIGroup()->getMemberUIDs()),
+                );
                 break;
             case "HasOneSshKey":
                 $this->assertEquals(1, count($USER->getSSHKeys()));
@@ -431,7 +434,7 @@ class UnityWebPortalTestCase extends TestCase
         global $USER, $SQL;
         $this->assertEquals(
             $expected,
-            $SQL->requestExists($USER->uid, UnitySQL::REQUEST_BECOME_PI),
+            $SQL->requestExists($USER->uid, UnitySQL::REQUEST_CREATE_PI_GROUP),
         );
     }
 
@@ -453,9 +456,9 @@ class UnityWebPortalTestCase extends TestCase
     {
         global $USER, $SQL;
         if ($x == 0) {
-            $this->assertFalse($SQL->requestExists($USER->uid, UnitySQL::REQUEST_BECOME_PI));
+            $this->assertFalse($SQL->requestExists($USER->uid, UnitySQL::REQUEST_CREATE_PI_GROUP));
         } elseif ($x > 0) {
-            $this->assertTrue($SQL->requestExists($USER->uid, UnitySQL::REQUEST_BECOME_PI));
+            $this->assertTrue($SQL->requestExists($USER->uid, UnitySQL::REQUEST_CREATE_PI_GROUP));
         } else {
             throw new RuntimeException("x must not be negative");
         }

--- a/test/phpunit-bootstrap.php
+++ b/test/phpunit-bootstrap.php
@@ -245,7 +245,7 @@ class UnityWebPortalTestCase extends TestCase
         "Blank" => "user2_org1_test",
         "EmptyPIGroupOwner" => "user5_org2_test",
         "CourseGroupOwner" => "cs123_org1_test",
-        "CourseGroupManager" => "user1_org1_test",
+        "CourseGroupManager" => "user2_org1_test",
         "CustomMapped555" => "user2002_org998_test",
         "Disabled" => "user7_org1_test",
         "DisabledNotPI" => "user7_org1_test",

--- a/test/phpunit-bootstrap.php
+++ b/test/phpunit-bootstrap.php
@@ -244,8 +244,8 @@ class UnityWebPortalTestCase extends TestCase
         "Admin" => "user1_org1_test",
         "Blank" => "user2_org1_test",
         "EmptyPIGroupOwner" => "user5_org2_test",
-        "CourseGroupOwner" => "cs123_org1_test",
-        "CourseGroupManager" => "user2_org1_test",
+        "CourseGroupOwner" => "user1_org1_test",
+        "CourseGroupManager" => "user3_org1_test",
         "CustomMapped555" => "user2002_org998_test",
         "Disabled" => "user7_org1_test",
         "DisabledNotPI" => "user7_org1_test",
@@ -289,7 +289,7 @@ class UnityWebPortalTestCase extends TestCase
                 break;
             case "CourseGroupOwner":
                 $this->assertTrue($USER->getNamesakePIGroup()->exists());
-                $this->assertNotEmpty($USER->getNamesakePIGroup()->getManagerUIDs());
+                $this->assertNotEmpty($LDAP->getPIGroupGIDsWithOwnerUID($USER->uid));
                 break;
             case "CourseGroupManager":
                 $this->assertNotEmpty($LDAP->getPIGroupGIDsWithManagerUID($USER->uid));

--- a/tools/docker-dev/identity/account-portal-schema.ldif
+++ b/tools/docker-dev/identity/account-portal-schema.ldif
@@ -13,16 +13,16 @@ olcAttributeTypes: ( 1.1.3 NAME 'managerUid'
     SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
     )
 olcAttributeTypes: ( 1.1.4 NAME 'ownerUid'
-    DESC 'owner'
+    DESC 'group owner'
     EQUALITY caseIgnoreMatch
     SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
     SINGLE-VALUE
     )
 olcObjectClasses: ( 1.1.2 NAME 'piGroup' SUP top AUXILIARY
-    DESC 'PI Group'
+    DESC 'DEPRECATED, DO NOT USE'
     MAY ( isDisabled $ managerUid )
     )
 olcObjectClasses: ( 1.1.5 NAME 'unityGroup' SUP top AUXILIARY
-    DESC 'Unity Group'
+    DESC 'general-purpose group in the Unity HPC Platform'
     MAY ( isDisabled $ managerUid $ ownerUid )
     )

--- a/tools/docker-dev/identity/account-portal-schema.ldif
+++ b/tools/docker-dev/identity/account-portal-schema.ldif
@@ -12,7 +12,17 @@ olcAttributeTypes: ( 1.1.3 NAME 'managerUid'
     EQUALITY caseExactIA5Match
     SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
     )
+olcAttributeTypes: ( 1.1.4 NAME 'ownerUid'
+    DESC 'owner'
+    EQUALITY caseIgnoreMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+    SINGLE-VALUE
+    )
 olcObjectClasses: ( 1.1.2 NAME 'piGroup' SUP top AUXILIARY
     DESC 'PI Group'
     MAY ( isDisabled $ managerUid )
+    )
+olcObjectClasses: ( 1.1.5 NAME 'unityGroup' SUP top AUXILIARY
+    DESC 'Unity Group'
+    MAY ( isDisabled $ managerUid $ ownerUid )
     )

--- a/tools/docker-dev/identity/bootstrap.ldif
+++ b/tools/docker-dev/identity/bootstrap.ldif
@@ -37587,36 +37587,11 @@ gecos: Melissa Price
 uid: user2005_org1_test
 uidnumber: 33130
 
-dn: cn=cs123_org1_test,ou=user_groups,dc=unityhpc,dc=test
-objectClass: posixGroup
-objectClass: top
-gidNumber: 20005
-cn: cs123_org1_test
-
-dn: cn=cs123_org1_test,ou=users,dc=unityhpc,dc=test
-objectClass: inetOrgPerson
-objectClass: posixAccount
-objectClass: top
-objectClass: ldapPublicKey
-uid: cs123_org1_test
-givenName: cs123
-sn: Fall 2025
-gecos: cs123 Fall 2025
-mail: user1+cs123@org1.test
-o: org1_test
-homeDirectory: /home/cs123_org1_test
-loginShell: /bin/bash
-uidNumber: 20005
-gidNumber: 20005
-cn: cs123_org1_test
-
 dn: cn=pi_cs123_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 objectclass: unityGroup
 objectClass: posixGroup
 objectClass: top
 gidNumber: 20007
 cn: pi_cs123_org1_test
-owneruid: cs123_org1_test
-manageruid: user1_org1_test
-memberuid: cs123_org1_test
+owneruid: user1_org1_test
 memberuid: user1_org1_test

--- a/tools/docker-dev/identity/bootstrap.ldif
+++ b/tools/docker-dev/identity/bootstrap.ldif
@@ -10432,7 +10432,7 @@ cn: pi_user36_org2_test
 gidnumber: 10206
 memberuid: user36_org2_test
 memberuid: user912_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10505,7 +10505,7 @@ memberuid: user1095_org1_test
 memberuid: user414_org1_test
 memberuid: user1020_org1_test
 memberuid: user1177_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10513,7 +10513,7 @@ dn: cn=pi_user45_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user45_org1_test
 gidnumber: 10243
 memberuid: user45_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10522,7 +10522,7 @@ cn: pi_user51_org3_test
 gidnumber: 10222
 memberuid: user51_org3_test
 memberuid: user934_org3_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10541,7 +10541,7 @@ memberuid: user477_org1_test
 memberuid: user1265_org1_test
 memberuid: user1021_org1_test
 memberuid: user348_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10550,7 +10550,7 @@ cn: pi_user57_org2_test
 gidnumber: 10132
 memberuid: user57_org2_test
 memberuid: user67_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10558,7 +10558,7 @@ dn: cn=pi_user66_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user66_org2_test
 gidnumber: 10199
 memberuid: user66_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10573,7 +10573,7 @@ memberuid: user1073_org1_test
 memberuid: user1257_org1_test
 memberuid: user85_org1_test
 memberuid: user41_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10582,7 +10582,7 @@ cn: pi_user72_org3_test
 gidnumber: 10223
 memberuid: user72_org3_test
 memberuid: user1223_org3_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10591,7 +10591,7 @@ cn: pi_user78_org1_test
 gidnumber: 10157
 memberuid: user78_org1_test
 memberuid: user526_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10599,7 +10599,7 @@ dn: cn=pi_user93_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user93_org1_test
 gidnumber: 10101
 memberuid: user93_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10615,7 +10615,7 @@ memberuid: user747_org1_test
 memberuid: user516_org1_test
 memberuid: user821_org1_test
 memberuid: user1196_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10624,7 +10624,7 @@ cn: pi_user113_org1_test
 gidnumber: 10099
 memberuid: user113_org1_test
 memberuid: user272_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10637,7 +10637,7 @@ memberuid: user791_org2_test
 memberuid: user987_org2_test
 memberuid: user904_org2_test
 memberuid: user839_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10650,7 +10650,7 @@ memberuid: user60_org1_test
 memberuid: user29_org1_test
 memberuid: user46_org1_test
 memberuid: user734_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10660,7 +10660,7 @@ gidnumber: 10063
 memberuid: user135_org1_test
 memberuid: user860_org1_test
 memberuid: user574_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10672,7 +10672,7 @@ memberuid: user512_org3_test
 memberuid: user406_org3_test
 memberuid: user1054_org3_test
 memberuid: user850_org3_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10681,7 +10681,7 @@ cn: pi_user149_org1_test
 gidnumber: 10071
 memberuid: user149_org1_test
 memberuid: user263_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10691,7 +10691,7 @@ gidnumber: 10254
 memberuid: user150_org1_test
 memberuid: user1250_org1_test
 memberuid: user208_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10699,7 +10699,7 @@ dn: cn=pi_user162_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user162_org1_test
 gidnumber: 10228
 memberuid: user162_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10709,7 +10709,7 @@ gidnumber: 10179
 memberuid: user163_org1_test
 memberuid: user300_org1_test
 memberuid: user749_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10717,7 +10717,7 @@ dn: cn=pi_user166_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user166_org2_test
 gidnumber: 10165
 memberuid: user166_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10727,7 +10727,7 @@ gidnumber: 10009
 memberuid: user167_org1_test
 memberuid: user1097_org1_test
 memberuid: user690_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10735,7 +10735,7 @@ dn: cn=pi_user176_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user176_org2_test
 gidnumber: 10216
 memberuid: user176_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10744,7 +10744,7 @@ cn: pi_user181_org1_test
 gidnumber: 10245
 memberuid: user181_org1_test
 memberuid: user909_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10754,7 +10754,7 @@ gidnumber: 10150
 memberuid: user182_org1_test
 memberuid: user752_org1_test
 memberuid: user529_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10766,7 +10766,7 @@ memberuid: user99_org1_test
 memberuid: user1141_org1_test
 memberuid: user236_org1_test
 memberuid: user757_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10774,7 +10774,7 @@ dn: cn=pi_user188_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user188_org1_test
 gidnumber: 10143
 memberuid: user188_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10784,7 +10784,7 @@ gidnumber: 10260
 memberuid: user190_org000000007_test
 memberuid: user211_org000000007_test
 memberuid: user1164_org000000007_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10793,7 +10793,7 @@ cn: pi_user191_org2_test
 gidnumber: 10181
 memberuid: user191_org2_test
 memberuid: user1113_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10812,7 +10812,7 @@ memberuid: user1032_org13_test
 memberuid: user851_org1_test
 memberuid: user576_org1_test
 memberuid: user508_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10820,7 +10820,7 @@ dn: cn=pi_user5_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user5_org2_test
 gidnumber: 10135
 memberuid: user5_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10830,7 +10830,7 @@ gidnumber: 10230
 memberuid: user197_org3_test
 memberuid: user639_org3_test
 memberuid: user748_org3_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10843,7 +10843,7 @@ memberuid: user269_org1_test
 memberuid: user1007_org1_test
 memberuid: user1258_org1_test
 memberuid: user317_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10852,7 +10852,7 @@ cn: pi_user200_org2_test
 gidnumber: 10275
 memberuid: user200_org2_test
 memberuid: user662_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10860,7 +10860,7 @@ dn: cn=pi_user201_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user201_org1_test
 gidnumber: 10010
 memberuid: user201_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10868,7 +10868,7 @@ dn: cn=pi_user205_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user205_org1_test
 gidnumber: 10274
 memberuid: user205_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10881,7 +10881,7 @@ memberuid: user588_org1_test
 memberuid: user384_org1_test
 memberuid: user1081_org1_test
 memberuid: user772_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10889,7 +10889,7 @@ dn: cn=pi_user207_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user207_org1_test
 gidnumber: 10220
 memberuid: user207_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10904,7 +10904,7 @@ memberuid: user566_org1_test
 memberuid: user511_org1_test
 memberuid: user950_org1_test
 memberuid: user894_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10912,7 +10912,7 @@ dn: cn=pi_user214_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user214_org1_test
 gidnumber: 10145
 memberuid: user214_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10928,7 +10928,7 @@ memberuid: user1016_org1_test
 memberuid: user776_org1_test
 memberuid: user1285_org1_test
 memberuid: user472_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10940,7 +10940,7 @@ memberuid: user645_org1_test
 memberuid: user745_org1_test
 memberuid: user230_org1_test
 memberuid: user364_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10948,14 +10948,14 @@ dn: cn=pi_user226_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user226_org3_test
 gidnumber: 10164
 memberuid: user226_org3_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
 dn: cn=pi_user9_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user9_org3_test
 gidnumber: 10094
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 isDisabled: TRUE
@@ -10964,7 +10964,7 @@ manageruid: user12_org1_test
 dn: cn=pi_user10_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user10_org1_test
 gidnumber: 2257
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 isDisabled: TRUE
@@ -10973,7 +10973,7 @@ dn: cn=pi_user242_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user242_org1_test
 gidnumber: 10052
 memberuid: user242_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10982,7 +10982,7 @@ cn: pi_user247_org1_test
 gidnumber: 10126
 memberuid: user247_org1_test
 memberuid: user178_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -10994,7 +10994,7 @@ memberuid: user482_org1_test
 memberuid: user254_org1_test
 memberuid: user1239_org1_test
 memberuid: user918_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11002,7 +11002,7 @@ dn: cn=pi_user253_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user253_org1_test
 gidnumber: 10013
 memberuid: user253_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11027,7 +11027,7 @@ memberuid: user767_org1_test
 memberuid: user56_org1_test
 memberuid: user1200_org1_test
 memberuid: user280_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11035,7 +11035,7 @@ dn: cn=pi_user264_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user264_org1_test
 gidnumber: 10073
 memberuid: user264_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11044,7 +11044,7 @@ cn: pi_user266_org1_test
 gidnumber: 10162
 memberuid: user266_org1_test
 memberuid: user111_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11052,7 +11052,7 @@ dn: cn=pi_user268_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user268_org1_test
 gidnumber: 10239
 memberuid: user268_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11060,7 +11060,7 @@ dn: cn=pi_user274_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user274_org2_test
 gidnumber: 10283
 memberuid: user274_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11072,7 +11072,7 @@ memberuid: user978_org1_test
 memberuid: user155_org1_test
 memberuid: user629_org1_test
 memberuid: user217_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11081,7 +11081,7 @@ cn: pi_user278_org3_test
 gidnumber: 10180
 memberuid: user278_org3_test
 memberuid: user20_org3_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11089,7 +11089,7 @@ dn: cn=pi_user288_org000000007_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user288_org000000007_test
 gidnumber: 10234
 memberuid: user288_org000000007_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11100,7 +11100,7 @@ memberuid: user291_org1_test
 memberuid: user473_org1_test
 memberuid: user110_org1_test
 memberuid: user441_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11108,7 +11108,7 @@ dn: cn=pi_user292_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user292_org2_test
 gidnumber: 10229
 memberuid: user292_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11116,7 +11116,7 @@ dn: cn=pi_user295_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user295_org3_test
 gidnumber: 10277
 memberuid: user295_org3_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11126,7 +11126,7 @@ gidnumber: 10209
 memberuid: user303_org1_test
 memberuid: user365_org1_test
 memberuid: user389_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11134,7 +11134,7 @@ dn: cn=pi_user304_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user304_org1_test
 gidnumber: 10248
 memberuid: user304_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11146,7 +11146,7 @@ memberuid: user58_org1_test
 memberuid: user824_org1_test
 memberuid: user21_org1_test
 memberuid: user447_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11157,7 +11157,7 @@ memberuid: user312_org1_test
 memberuid: user794_org1_test
 memberuid: user1031_org1_test
 memberuid: user556_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11167,7 +11167,7 @@ gidnumber: 10112
 memberuid: user315_org2_test
 memberuid: user392_org2_test
 memberuid: user866_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11176,7 +11176,7 @@ cn: pi_user326_org3_test
 gidnumber: 10173
 memberuid: user326_org3_test
 memberuid: user883_org3_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11186,7 +11186,7 @@ gidnumber: 10136
 memberuid: user329_org1_test
 memberuid: user46_org1_test
 memberuid: user148_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11194,7 +11194,7 @@ dn: cn=pi_user331_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user331_org1_test
 gidnumber: 10227
 memberuid: user331_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11203,7 +11203,7 @@ cn: pi_user336_org1_test
 gidnumber: 10137
 memberuid: user336_org1_test
 memberuid: user478_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11212,7 +11212,7 @@ cn: pi_user338_org1_test
 gidnumber: 10267
 memberuid: user338_org1_test
 memberuid: user1149_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11227,7 +11227,7 @@ memberuid: user570_org1_test
 memberuid: user888_org1_test
 memberuid: user343_org1_test
 memberuid: user535_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11236,7 +11236,7 @@ cn: pi_user345_org1_test
 gidnumber: 10186
 memberuid: user345_org1_test
 memberuid: user1084_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11244,7 +11244,7 @@ dn: cn=pi_user346_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user346_org2_test
 gidnumber: 10246
 memberuid: user346_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11253,7 +11253,7 @@ cn: pi_user347_org2_test
 gidnumber: 10081
 memberuid: user347_org2_test
 memberuid: user24_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11261,7 +11261,7 @@ dn: cn=pi_user354_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user354_org1_test
 gidnumber: 10016
 memberuid: user354_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11276,7 +11276,7 @@ memberuid: user908_org1_test
 memberuid: user434_org1_test
 memberuid: user1180_org1_test
 memberuid: user1024_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11284,7 +11284,7 @@ dn: cn=pi_user372_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user372_org1_test
 gidnumber: 10053
 memberuid: user372_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11298,7 +11298,7 @@ memberuid: user301_org1_test
 memberuid: user401_org1_test
 memberuid: user306_org1_test
 memberuid: user1286_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11307,7 +11307,7 @@ cn: pi_user382_org1_test
 gidnumber: 10219
 memberuid: user382_org1_test
 memberuid: user590_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11315,7 +11315,7 @@ dn: cn=pi_user386_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user386_org1_test
 gidnumber: 10197
 memberuid: user386_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11325,7 +11325,7 @@ gidnumber: 10098
 memberuid: user391_org1_test
 memberuid: user63_org1_test
 memberuid: user874_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11333,7 +11333,7 @@ dn: cn=pi_user393_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user393_org1_test
 gidnumber: 10017
 memberuid: user393_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11342,7 +11342,7 @@ cn: pi_user395_org1_test
 gidnumber: 10122
 memberuid: user395_org1_test
 memberuid: user993_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11351,7 +11351,7 @@ cn: pi_user398_org1_test
 gidnumber: 10169
 memberuid: user398_org1_test
 memberuid: user394_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11362,7 +11362,7 @@ memberuid: user400_org1_test
 memberuid: user712_org1_test
 memberuid: user91_org1_test
 memberuid: user653_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11371,7 +11371,7 @@ cn: pi_user404_org3_test
 gidnumber: 10152
 memberuid: user404_org3_test
 memberuid: user145_org3_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11379,7 +11379,7 @@ dn: cn=pi_user407_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user407_org1_test
 gidnumber: 10238
 memberuid: user407_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11390,7 +11390,7 @@ memberuid: user415_org3_test
 memberuid: user261_org3_test
 memberuid: user14_org3_test
 memberuid: user333_org3_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11399,7 +11399,7 @@ cn: pi_user416_org1_test
 gidnumber: 10279
 memberuid: user416_org1_test
 memberuid: user952_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11408,7 +11408,7 @@ cn: pi_user420_org1_test
 gidnumber: 10147
 memberuid: user420_org1_test
 memberuid: user977_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11417,7 +11417,7 @@ cn: pi_user423_org1_test
 gidnumber: 10252
 memberuid: user423_org1_test
 memberuid: user1211_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11433,7 +11433,7 @@ memberuid: user972_org10_test
 memberuid: user251_org2_test
 memberuid: user170_org2_test
 memberuid: user1002_org3_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11444,7 +11444,7 @@ memberuid: user426_org3_test
 memberuid: user112_org3_test
 memberuid: user944_org3_test
 memberuid: user202_org3_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11453,7 +11453,7 @@ cn: pi_user432_org2_test
 gidnumber: 10212
 memberuid: user432_org2_test
 memberuid: user595_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11462,7 +11462,7 @@ cn: pi_user433_org1_test
 gidnumber: 10156
 memberuid: user433_org1_test
 memberuid: user209_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11470,7 +11470,7 @@ dn: cn=pi_user436_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user436_org2_test
 gidnumber: 10236
 memberuid: user436_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11486,7 +11486,7 @@ memberuid: user422_org1_test
 memberuid: user168_org1_test
 memberuid: user759_org1_test
 memberuid: user661_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11497,7 +11497,7 @@ memberuid: user439_org2_test
 memberuid: user412_org2_test
 memberuid: user780_org2_test
 memberuid: user1133_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11508,7 +11508,7 @@ memberuid: user440_org1_test
 memberuid: user89_org1_test
 memberuid: user1080_org1_test
 memberuid: user146_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11518,7 +11518,7 @@ gidnumber: 10263
 memberuid: user442_org1_test
 memberuid: user700_org1_test
 memberuid: user1053_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11540,7 +11540,7 @@ memberuid: user1155_org1_test
 memberuid: user1008_org1_test
 memberuid: user468_org1_test
 memberuid: user240_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11550,7 +11550,7 @@ gidnumber: 10003
 memberuid: user452_org1_test
 memberuid: user316_org1_test
 memberuid: user746_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11560,7 +11560,7 @@ gidnumber: 10118
 memberuid: user453_org1_test
 memberuid: user1210_org1_test
 memberuid: user555_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11576,7 +11576,7 @@ memberuid: user874_org1_test
 memberuid: user963_org1_test
 memberuid: user397_org1_test
 memberuid: user910_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11585,7 +11585,7 @@ cn: pi_user460_org1_test
 gidnumber: 10172
 memberuid: user460_org1_test
 memberuid: user172_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11593,7 +11593,7 @@ dn: cn=pi_user466_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user466_org2_test
 gidnumber: 10166
 memberuid: user466_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11603,7 +11603,7 @@ gidnumber: 10129
 memberuid: user467_org2_test
 memberuid: user723_org2_test
 memberuid: user259_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11612,7 +11612,7 @@ cn: pi_user480_org1_test
 gidnumber: 10168
 memberuid: user480_org1_test
 memberuid: user900_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11651,7 +11651,7 @@ memberuid: user899_org1_test
 memberuid: user924_org1_test
 memberuid: user1295_org1_test
 memberuid: user1061_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11668,7 +11668,7 @@ memberuid: user553_org2_test
 memberuid: user129_org2_test
 memberuid: user669_org2_test
 memberuid: user648_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11700,7 +11700,7 @@ memberuid: user982_org1_test
 memberuid: user75_org1_test
 memberuid: user151_org1_test
 memberuid: user557_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11724,7 +11724,7 @@ memberuid: user895_org1_test
 memberuid: user623_org1_test
 memberuid: user97_org1_test
 memberuid: user953_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11735,7 +11735,7 @@ memberuid: user502_org1_test
 memberuid: user1072_org1_test
 memberuid: user1194_org1_test
 memberuid: user82_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11749,7 +11749,7 @@ memberuid: user716_org2_test
 memberuid: user584_org2_test
 memberuid: user788_org2_test
 memberuid: user170_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11757,7 +11757,7 @@ dn: cn=pi_user513_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user513_org1_test
 gidnumber: 10108
 memberuid: user513_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11767,7 +11767,7 @@ gidnumber: 10251
 memberuid: user517_org1_test
 memberuid: user1253_org1_test
 memberuid: user616_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11775,7 +11775,7 @@ dn: cn=pi_user519_org000000007_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user519_org000000007_test
 gidnumber: 10259
 memberuid: user519_org000000007_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11784,7 +11784,7 @@ cn: pi_user528_org1_test
 gidnumber: 10104
 memberuid: user528_org1_test
 memberuid: user799_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11796,7 +11796,7 @@ memberuid: user1222_org1_test
 memberuid: user16_org1_test
 memberuid: user1131_org1_test
 memberuid: user402_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11804,7 +11804,7 @@ dn: cn=pi_user532_org000000007_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user532_org000000007_test
 gidnumber: 10174
 memberuid: user532_org000000007_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11817,7 +11817,7 @@ memberuid: user353_org1_test
 memberuid: user869_org1_test
 memberuid: user1116_org1_test
 memberuid: user896_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11879,7 +11879,7 @@ memberuid: user1218_org1_test
 memberuid: user1202_org1_test
 memberuid: user1217_org1_test
 memberuid: user960_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11899,7 +11899,7 @@ memberuid: user491_org4_test
 memberuid: user689_org1_test
 memberuid: user12_org1_test
 memberuid: user697_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11908,7 +11908,7 @@ cn: pi_user546_org1_test
 gidnumber: 10193
 memberuid: user546_org1_test
 memberuid: user103_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11917,7 +11917,7 @@ cn: pi_user550_org1_test
 gidnumber: 10187
 memberuid: user550_org1_test
 memberuid: user1107_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11931,7 +11931,7 @@ memberuid: user385_org1_test
 memberuid: user1219_org1_test
 memberuid: user992_org1_test
 memberuid: user1023_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11939,7 +11939,7 @@ dn: cn=pi_user554_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user554_org2_test
 gidnumber: 10241
 memberuid: user554_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11948,7 +11948,7 @@ cn: pi_user559_org1_test
 gidnumber: 10004
 memberuid: user559_org1_test
 memberuid: user509_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11958,7 +11958,7 @@ gidnumber: 10057
 memberuid: user560_org1_test
 memberuid: user875_org1_test
 memberuid: user589_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11968,7 +11968,7 @@ gidnumber: 10054
 memberuid: user561_org1_test
 memberuid: user932_org1_test
 memberuid: user25_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -11976,7 +11976,7 @@ dn: cn=pi_user564_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user564_org1_test
 gidnumber: 10123
 memberuid: user564_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12010,7 +12010,7 @@ memberuid: user544_org1_test
 memberuid: user61_org1_test
 memberuid: user846_org1_test
 memberuid: user1167_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12027,7 +12027,7 @@ memberuid: user611_org1_test
 memberuid: user1132_org1_test
 memberuid: user378_org1_test
 memberuid: user143_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12036,7 +12036,7 @@ cn: pi_user575_org1_test
 gidnumber: 10092
 memberuid: user575_org1_test
 memberuid: user863_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12044,7 +12044,7 @@ dn: cn=pi_user580_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user580_org1_test
 gidnumber: 10119
 memberuid: user580_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12052,7 +12052,7 @@ dn: cn=pi_user582_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user582_org1_test
 gidnumber: 10051
 memberuid: user582_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12060,7 +12060,7 @@ dn: cn=pi_user586_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user586_org1_test
 gidnumber: 10020
 memberuid: user586_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12072,7 +12072,7 @@ memberuid: user1104_org1_test
 memberuid: user357_org1_test
 memberuid: user39_org1_test
 memberuid: user281_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12081,7 +12081,7 @@ cn: pi_user592_org2_test
 gidnumber: 10235
 memberuid: user592_org2_test
 memberuid: user410_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12104,7 +12104,7 @@ memberuid: user234_org9_test
 memberuid: user258_org1_test
 memberuid: user728_org9_test
 memberuid: user1147_org9_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12112,7 +12112,7 @@ dn: cn=pi_user608_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user608_org1_test
 gidnumber: 10070
 memberuid: user608_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12125,7 +12125,7 @@ memberuid: user37_org1_test
 memberuid: user1216_org1_test
 memberuid: user583_org1_test
 memberuid: user838_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12133,7 +12133,7 @@ dn: cn=pi_user626_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user626_org1_test
 gidnumber: 10107
 memberuid: user626_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12141,7 +12141,7 @@ dn: cn=pi_user635_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user635_org1_test
 gidnumber: 10175
 memberuid: user635_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12150,7 +12150,7 @@ cn: pi_user636_org2_test
 gidnumber: 10195
 memberuid: user636_org2_test
 memberuid: user694_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12161,7 +12161,7 @@ memberuid: user641_org1_test
 memberuid: user239_org1_test
 memberuid: user1017_org1_test
 memberuid: user409_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12171,7 +12171,7 @@ gidnumber: 10115
 memberuid: user647_org1_test
 memberuid: user739_org1_test
 memberuid: user800_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12180,7 +12180,7 @@ cn: pi_user656_org1_test
 gidnumber: 10064
 memberuid: user656_org1_test
 memberuid: user80_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12189,7 +12189,7 @@ cn: pi_user659_org1_test
 gidnumber: 10144
 memberuid: user659_org1_test
 memberuid: user265_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12197,7 +12197,7 @@ dn: cn=pi_user663_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user663_org2_test
 gidnumber: 10202
 memberuid: user663_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12209,7 +12209,7 @@ memberuid: user495_org1_test
 memberuid: user319_org1_test
 memberuid: user678_org1_test
 memberuid: user379_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12218,7 +12218,7 @@ cn: pi_user670_org1_test
 gidnumber: 10062
 memberuid: user670_org1_test
 memberuid: user195_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12227,7 +12227,7 @@ cn: pi_user674_org1_test
 gidnumber: 10217
 memberuid: user674_org1_test
 memberuid: user680_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12240,7 +12240,7 @@ memberuid: user62_org1_test
 memberuid: user649_org1_test
 memberuid: user381_org1_test
 memberuid: user1085_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12251,7 +12251,7 @@ memberuid: user677_org1_test
 memberuid: user1294_org1_test
 memberuid: user1161_org1_test
 memberuid: user484_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12277,7 +12277,7 @@ memberuid: user533_org1_test
 memberuid: user524_org1_test
 memberuid: user596_org1_test
 memberuid: user267_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12293,7 +12293,7 @@ memberuid: user352_org1_test
 memberuid: user825_org1_test
 memberuid: user598_org1_test
 memberuid: user618_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12303,7 +12303,7 @@ gidnumber: 10211
 memberuid: user695_org2_test
 memberuid: user705_org2_test
 memberuid: user541_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12313,7 +12313,7 @@ gidnumber: 10075
 memberuid: user699_org1_test
 memberuid: user665_org1_test
 memberuid: user44_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12321,7 +12321,7 @@ dn: cn=pi_user703_org11_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user703_org11_test
 gidnumber: 10207
 memberuid: user703_org11_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12331,7 +12331,7 @@ gidnumber: 10044
 memberuid: user714_org2_test
 memberuid: user760_org2_test
 memberuid: user538_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12341,7 +12341,7 @@ gidnumber: 10200
 memberuid: user717_org2_test
 memberuid: user189_org2_test
 memberuid: user929_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12351,7 +12351,7 @@ gidnumber: 10161
 memberuid: user720_org1_test
 memberuid: user171_org1_test
 memberuid: user470_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12363,7 +12363,7 @@ memberuid: user276_org1_test
 memberuid: user497_org1_test
 memberuid: user811_org1_test
 memberuid: user88_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12372,7 +12372,7 @@ cn: pi_user724_org1_test
 gidnumber: 10045
 memberuid: user724_org1_test
 memberuid: user864_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12381,7 +12381,7 @@ cn: pi_user725_org2_test
 gidnumber: 10198
 memberuid: user725_org2_test
 memberuid: user876_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12390,7 +12390,7 @@ cn: pi_user727_org000000007_test
 gidnumber: 10266
 memberuid: user727_org000000007_test
 memberuid: user1192_org000000007_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12404,7 +12404,7 @@ memberuid: user38_org1_test
 memberuid: user377_org1_test
 memberuid: user224_org1_test
 memberuid: user451_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12416,7 +12416,7 @@ memberuid: user852_org1_test
 memberuid: user971_org1_test
 memberuid: user1139_org1_test
 memberuid: user951_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12470,7 +12470,7 @@ memberuid: user597_org1_test
 memberuid: user139_org1_test
 memberuid: user1026_org1_test
 memberuid: user109_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12478,7 +12478,7 @@ dn: cn=pi_user737_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user737_org1_test
 gidnumber: 10039
 memberuid: user737_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12488,7 +12488,7 @@ gidnumber: 10069
 memberuid: user743_org1_test
 memberuid: user1263_org1_test
 memberuid: user1098_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12498,7 +12498,7 @@ gidnumber: 10022
 memberuid: user744_org1_test
 memberuid: user704_org1_test
 memberuid: user787_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12517,7 +12517,7 @@ memberuid: user627_org1_test
 memberuid: user552_org1_test
 memberuid: user891_org1_test
 memberuid: user1034_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12525,7 +12525,7 @@ dn: cn=pi_user758_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user758_org1_test
 gidnumber: 10278
 memberuid: user758_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12533,7 +12533,7 @@ dn: cn=pi_user764_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user764_org1_test
 gidnumber: 10237
 memberuid: user764_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12555,7 +12555,7 @@ memberuid: user1248_org1_test
 memberuid: user854_org1_test
 memberuid: user984_org1_test
 memberuid: user1157_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12568,7 +12568,7 @@ memberuid: user729_org3_test
 memberuid: user15_org3_test
 memberuid: user417_org3_test
 memberuid: user766_org3_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12577,7 +12577,7 @@ cn: pi_user782_org1_test
 gidnumber: 10059
 memberuid: user782_org1_test
 memberuid: user1162_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12587,7 +12587,7 @@ gidnumber: 10167
 memberuid: user783_org1_test
 memberuid: user1057_org1_test
 memberuid: user991_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12596,7 +12596,7 @@ cn: pi_user784_org1_test
 gidnumber: 10281
 memberuid: user784_org1_test
 memberuid: user228_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12609,7 +12609,7 @@ memberuid: user1160_org1_test
 memberuid: user650_org1_test
 memberuid: user492_org1_test
 memberuid: user1256_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12620,7 +12620,7 @@ memberuid: user786_org1_test
 memberuid: user1146_org1_test
 memberuid: user301_org1_test
 memberuid: user942_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12628,7 +12628,7 @@ dn: cn=pi_user788_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user788_org2_test
 gidnumber: 10191
 memberuid: user788_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12642,7 +12642,7 @@ memberuid: user74_org3_test
 memberuid: user644_org3_test
 memberuid: user231_org3_test
 memberuid: user630_org3_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12650,7 +12650,7 @@ dn: cn=pi_user795_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user795_org1_test
 gidnumber: 10178
 memberuid: user795_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12659,7 +12659,7 @@ cn: pi_user796_org11_test
 gidnumber: 10133
 memberuid: user796_org11_test
 memberuid: user710_org11_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12668,7 +12668,7 @@ cn: pi_user798_org1_test
 gidnumber: 10035
 memberuid: user798_org1_test
 memberuid: user756_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12676,7 +12676,7 @@ dn: cn=pi_user801_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user801_org1_test
 gidnumber: 10271
 memberuid: user801_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12685,7 +12685,7 @@ cn: pi_user803_org1_test
 gidnumber: 10025
 memberuid: user803_org1_test
 memberuid: user1058_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12696,7 +12696,7 @@ memberuid: user805_org3_test
 memberuid: user154_org3_test
 memberuid: user672_org3_test
 memberuid: user673_org3_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12704,7 +12704,7 @@ dn: cn=pi_user809_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user809_org2_test
 gidnumber: 10190
 memberuid: user809_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12717,7 +12717,7 @@ memberuid: user998_org1_test
 memberuid: user581_org1_test
 memberuid: user1142_org1_test
 memberuid: user504_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12725,7 +12725,7 @@ dn: cn=pi_user830_org11_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user830_org11_test
 gidnumber: 10100
 memberuid: user830_org11_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12733,7 +12733,7 @@ dn: cn=pi_user832_org14_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user832_org14_test
 gidnumber: 10268
 memberuid: user832_org14_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12745,7 +12745,7 @@ memberuid: user379_org1_test
 memberuid: user335_org1_test
 memberuid: user701_org1_test
 memberuid: user763_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12753,7 +12753,7 @@ dn: cn=pi_user834_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user834_org2_test
 gidnumber: 10224
 memberuid: user834_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12762,7 +12762,7 @@ cn: pi_user848_org1_test
 gidnumber: 10225
 memberuid: user848_org1_test
 memberuid: user284_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12770,7 +12770,7 @@ dn: cn=pi_user849_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user849_org1_test
 gidnumber: 10160
 memberuid: user849_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12780,7 +12780,7 @@ gidnumber: 10027
 memberuid: user857_org1_test
 memberuid: user1036_org1_test
 memberuid: user708_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12789,7 +12789,7 @@ cn: pi_user859_org1_test
 gidnumber: 10158
 memberuid: user859_org1_test
 memberuid: user96_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12797,7 +12797,7 @@ dn: cn=pi_user865_org000000007_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user865_org000000007_test
 gidnumber: 10221
 memberuid: user865_org000000007_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12805,7 +12805,7 @@ dn: cn=pi_user868_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user868_org1_test
 gidnumber: 10076
 memberuid: user868_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12813,7 +12813,7 @@ dn: cn=pi_user870_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user870_org3_test
 gidnumber: 10233
 memberuid: user870_org3_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12821,7 +12821,7 @@ dn: cn=pi_user872_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user872_org1_test
 gidnumber: 10038
 memberuid: user872_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12829,7 +12829,7 @@ dn: cn=pi_user873_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user873_org2_test
 gidnumber: 10142
 memberuid: user873_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12837,7 +12837,7 @@ dn: cn=pi_user875_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user875_org1_test
 gidnumber: 10185
 memberuid: user875_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12858,7 +12858,7 @@ memberuid: user457_org1_test
 memberuid: user286_org1_test
 memberuid: user884_org1_test
 memberuid: user562_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12866,7 +12866,7 @@ dn: cn=pi_user878_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user878_org2_test
 gidnumber: 10214
 memberuid: user878_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12874,7 +12874,7 @@ dn: cn=pi_user879_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user879_org1_test
 gidnumber: 10037
 memberuid: user879_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12884,7 +12884,7 @@ gidnumber: 10086
 memberuid: user881_org1_test
 memberuid: user1203_org1_test
 memberuid: user220_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12894,7 +12894,7 @@ gidnumber: 10215
 memberuid: user882_org1_test
 memberuid: user941_org1_test
 memberuid: user238_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12904,7 +12904,7 @@ gidnumber: 10029
 memberuid: user885_org1_test
 memberuid: user742_org1_test
 memberuid: user490_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12912,7 +12912,7 @@ dn: cn=pi_user886_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user886_org1_test
 gidnumber: 10121
 memberuid: user886_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12920,7 +12920,7 @@ dn: cn=pi_user890_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user890_org3_test
 gidnumber: 10182
 memberuid: user890_org3_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12928,7 +12928,7 @@ dn: cn=pi_user905_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user905_org1_test
 gidnumber: 10272
 memberuid: user905_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12937,7 +12937,7 @@ cn: pi_user915_org1_test
 gidnumber: 10184
 memberuid: user915_org1_test
 memberuid: user431_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12945,7 +12945,7 @@ dn: cn=pi_user917_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user917_org1_test
 gidnumber: 10280
 memberuid: user917_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12953,7 +12953,7 @@ dn: cn=pi_user928_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user928_org1_test
 gidnumber: 10050
 memberuid: user928_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12961,7 +12961,7 @@ dn: cn=pi_user931_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user931_org1_test
 gidnumber: 10253
 memberuid: user931_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12972,7 +12972,7 @@ memberuid: user933_org2_test
 memberuid: user122_org2_test
 memberuid: user617_org2_test
 memberuid: user1050_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12982,7 +12982,7 @@ gidnumber: 10114
 memberuid: user935_org1_test
 memberuid: user106_org1_test
 memberuid: user115_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -12991,7 +12991,7 @@ cn: pi_user936_org1_test
 gidnumber: 10061
 memberuid: user936_org1_test
 memberuid: user831_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13001,7 +13001,7 @@ gidnumber: 10171
 memberuid: user937_org1_test
 memberuid: user1195_org1_test
 memberuid: user356_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13011,7 +13011,7 @@ gidnumber: 10068
 memberuid: user938_org1_test
 memberuid: user907_org1_test
 memberuid: user1153_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13021,7 +13021,7 @@ gidnumber: 10183
 memberuid: user940_org3_test
 memberuid: user299_org3_test
 memberuid: user945_org3_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13032,7 +13032,7 @@ memberuid: user955_org2_test
 memberuid: user802_org2_test
 memberuid: user726_org2_test
 memberuid: user140_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13044,7 +13044,7 @@ memberuid: user31_org1_test
 memberuid: user454_org1_test
 memberuid: user390_org1_test
 memberuid: user1174_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13055,7 +13055,7 @@ memberuid: user962_org1_test
 memberuid: user696_org1_test
 memberuid: user350_org1_test
 memberuid: user624_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13067,7 +13067,7 @@ memberuid: user683_org1_test
 memberuid: user118_org1_test
 memberuid: user981_org1_test
 memberuid: user1159_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13075,7 +13075,7 @@ dn: cn=pi_user968_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user968_org2_test
 gidnumber: 10120
 memberuid: user968_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13088,7 +13088,7 @@ memberuid: user567_org1_test
 memberuid: user455_org1_test
 memberuid: user399_org1_test
 memberuid: user218_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13101,7 +13101,7 @@ memberuid: user408_org2_test
 memberuid: user322_org2_test
 memberuid: user375_org2_test
 memberuid: user985_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13110,7 +13110,7 @@ cn: pi_user1005_org3_test
 gidnumber: 10262
 memberuid: user1005_org3_test
 memberuid: user203_org3_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13119,7 +13119,7 @@ cn: pi_user1009_org1_test
 gidnumber: 10034
 memberuid: user1009_org1_test
 memberuid: user474_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13127,7 +13127,7 @@ dn: cn=pi_user1018_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1018_org2_test
 gidnumber: 10255
 memberuid: user1018_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13138,7 +13138,7 @@ memberuid: user1019_org3_test
 memberuid: user1138_org3_test
 memberuid: user812_org3_test
 memberuid: user646_org3_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13147,7 +13147,7 @@ cn: pi_user1022_org3_test
 gidnumber: 10163
 memberuid: user1022_org3_test
 memberuid: user159_org3_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13159,7 +13159,7 @@ memberuid: user21_org1_test
 memberuid: user161_org1_test
 memberuid: user824_org1_test
 memberuid: user447_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13168,7 +13168,7 @@ cn: pi_user1029_org1_test
 gidnumber: 10148
 memberuid: user1029_org1_test
 memberuid: user903_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13180,7 +13180,7 @@ memberuid: user1061_org1_test
 memberuid: user26_org1_test
 memberuid: user1069_org1_test
 memberuid: user79_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13188,7 +13188,7 @@ dn: cn=pi_user1039_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1039_org1_test
 gidnumber: 10256
 memberuid: user1039_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13198,7 +13198,7 @@ gidnumber: 10030
 memberuid: user1045_org1_test
 memberuid: user740_org1_test
 memberuid: user1154_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13206,7 +13206,7 @@ dn: cn=pi_user1053_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1053_org1_test
 gidnumber: 10258
 memberuid: user1053_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13214,7 +13214,7 @@ dn: cn=pi_user1056_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1056_org2_test
 gidnumber: 10270
 memberuid: user1056_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13230,7 +13230,7 @@ memberuid: user939_org1_test
 memberuid: user19_org1_test
 memberuid: user573_org1_test
 memberuid: user1090_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13241,7 +13241,7 @@ memberuid: user1076_org1_test
 memberuid: user227_org8_test
 memberuid: user1237_org1_test
 memberuid: user494_org8_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13253,7 +13253,7 @@ memberuid: user709_org2_test
 memberuid: user593_org2_test
 memberuid: user610_org2_test
 memberuid: user525_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13261,7 +13261,7 @@ dn: cn=pi_user1079_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1079_org1_test
 gidnumber: 10159
 memberuid: user1079_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13269,7 +13269,7 @@ dn: cn=pi_user1082_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1082_org1_test
 gidnumber: 10056
 memberuid: user1082_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13277,7 +13277,7 @@ dn: cn=pi_user1101_org14_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1101_org14_test
 gidnumber: 10269
 memberuid: user1101_org14_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13285,7 +13285,7 @@ dn: cn=pi_user1103_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1103_org2_test
 gidnumber: 10240
 memberuid: user1103_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13294,7 +13294,7 @@ cn: pi_user1109_org2_test
 gidnumber: 10192
 memberuid: user1109_org2_test
 memberuid: user520_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13303,7 +13303,7 @@ cn: pi_user1110_org2_test
 gidnumber: 10257
 memberuid: user1110_org2_test
 memberuid: user183_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13316,7 +13316,7 @@ memberuid: user605_org1_test
 memberuid: user1268_org1_test
 memberuid: user506_org1_test
 memberuid: user671_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13324,7 +13324,7 @@ dn: cn=pi_user1118_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1118_org1_test
 gidnumber: 10033
 memberuid: user1118_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13339,7 +13339,7 @@ memberuid: user131_org1_test
 memberuid: user1290_org1_test
 memberuid: user1197_org1_test
 memberuid: user806_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13353,7 +13353,7 @@ memberuid: user1126_org12_test
 memberuid: user1068_org12_test
 memberuid: user686_org12_test
 memberuid: user804_org12_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13361,7 +13361,7 @@ dn: cn=pi_user1128_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1128_org1_test
 gidnumber: 10284
 memberuid: user1128_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13370,7 +13370,7 @@ cn: pi_user1129_org1_test
 gidnumber: 10189
 memberuid: user1129_org1_test
 memberuid: user861_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13378,7 +13378,7 @@ dn: cn=pi_user1130_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1130_org1_test
 gidnumber: 10117
 memberuid: user1130_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13390,7 +13390,7 @@ memberuid: user1193_org5_test
 memberuid: user1121_org5_test
 memberuid: user855_org5_test
 memberuid: user76_org5_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13400,7 +13400,7 @@ gidnumber: 10055
 memberuid: user1165_org1_test
 memberuid: user1074_org1_test
 memberuid: user1299_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13408,7 +13408,7 @@ dn: cn=pi_user1171_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1171_org1_test
 gidnumber: 10250
 memberuid: user1171_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13420,7 +13420,7 @@ memberuid: user127_org1_test
 memberuid: user1289_org1_test
 memberuid: user1163_org1_test
 memberuid: user956_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13430,7 +13430,7 @@ gidnumber: 10188
 memberuid: user1176_org1_test
 memberuid: user845_org1_test
 memberuid: user314_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13439,7 +13439,7 @@ cn: pi_user1182_org2_test
 gidnumber: 10128
 memberuid: user1182_org2_test
 memberuid: user1189_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13447,7 +13447,7 @@ dn: cn=pi_user1185_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1185_org1_test
 gidnumber: 10213
 memberuid: user1185_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13455,7 +13455,7 @@ dn: cn=pi_user1187_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1187_org1_test
 gidnumber: 10208
 memberuid: user1187_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13464,7 +13464,7 @@ cn: pi_user1191_org2_test
 gidnumber: 10231
 memberuid: user1191_org2_test
 memberuid: user594_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13472,7 +13472,7 @@ dn: cn=pi_user1201_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1201_org1_test
 gidnumber: 10249
 memberuid: user1201_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13481,7 +13481,7 @@ cn: pi_user1227_org1_test
 gidnumber: 10244
 memberuid: user1227_org1_test
 memberuid: user260_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13490,7 +13490,7 @@ cn: pi_user1233_org1_test
 gidnumber: 10273
 memberuid: user1233_org1_test
 memberuid: user465_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13498,7 +13498,7 @@ dn: cn=pi_user1234_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1234_org1_test
 gidnumber: 10282
 memberuid: user1234_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13508,7 +13508,7 @@ gidnumber: 10041
 memberuid: user1235_org3_test
 memberuid: user961_org3_test
 memberuid: user313_org3_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13526,7 +13526,7 @@ memberuid: user77_org2_test
 memberuid: user210_org2_test
 memberuid: user657_org2_test
 memberuid: user69_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13534,7 +13534,7 @@ dn: cn=pi_user1255_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1255_org1_test
 gidnumber: 10146
 memberuid: user1255_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13543,7 +13543,7 @@ cn: pi_user1260_org2_test
 gidnumber: 10043
 memberuid: user1260_org2_test
 memberuid: user1215_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13554,7 +13554,7 @@ memberuid: user1280_org1_test
 memberuid: user1183_org1_test
 memberuid: user1224_org1_test
 memberuid: user1012_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13580,7 +13580,7 @@ memberuid: user47_org1_test
 memberuid: user443_org1_test
 memberuid: user1044_org1_test
 memberuid: user255_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13589,7 +13589,7 @@ cn: pi_user1293_org2_test
 gidnumber: 10265
 memberuid: user1293_org2_test
 memberuid: user537_org2_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -13597,7 +13597,7 @@ dn: cn=pi_user1298_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1298_org1_test
 gidnumber: 10210
 memberuid: user1298_org1_test
-objectclass: piGroup
+objectclass: unityGroup
 objectclass: posixGroup
 objectclass: top
 
@@ -37328,7 +37328,7 @@ gidNumber: 20005
 cn: cs123_org1_test
 
 dn: cn=pi_cs123_org1_test,ou=pi_groups,dc=unityhpc,dc=test
-objectclass: piGroup
+objectclass: unityGroup
 objectClass: posixGroup
 objectClass: top
 gidNumber: 20007

--- a/tools/docker-dev/identity/bootstrap.ldif
+++ b/tools/docker-dev/identity/bootstrap.ldif
@@ -1206,7 +1206,6 @@ memberuid: user1299_org1_test
 memberuid: user1300_org1_test
 memberuid: user1301_org1_test
 memberuid: user1304_org1_test
-memberuid: cs123_org1_test
 
 dn: cn=user15_org3_test,ou=user_groups,dc=unityhpc,dc=test
 cn: user15_org3_test

--- a/tools/docker-dev/identity/bootstrap.ldif
+++ b/tools/docker-dev/identity/bootstrap.ldif
@@ -37594,6 +37594,6 @@ objectClass: top
 gidNumber: 20007
 cn: pi_cs123_org1_test
 owneruid: user1_org1_test
-manageruid: user2_org1_test
+manageruid: user3_org1_test
 memberuid: user1_org1_test
-memberuid: user2_org1_test
+memberuid: user3_org1_test

--- a/tools/docker-dev/identity/bootstrap.ldif
+++ b/tools/docker-dev/identity/bootstrap.ldif
@@ -37594,4 +37594,6 @@ objectClass: top
 gidNumber: 20007
 cn: pi_cs123_org1_test
 owneruid: user1_org1_test
+manageruid: user2_org1_test
 memberuid: user1_org1_test
+memberuid: user2_org1_test

--- a/tools/docker-dev/identity/bootstrap.ldif
+++ b/tools/docker-dev/identity/bootstrap.ldif
@@ -10429,6 +10429,7 @@ objectclass: top
 
 dn: cn=pi_user36_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user36_org2_test
+owneruid: user36_org2_test
 gidnumber: 10206
 memberuid: user36_org2_test
 memberuid: user912_org2_test
@@ -10438,6 +10439,7 @@ objectclass: top
 
 dn: cn=pi_user42_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user42_org1_test
+owneruid: user42_org1_test
 gidnumber: 10264
 memberuid: user42_org1_test
 memberuid: user1052_org1_test
@@ -10511,6 +10513,7 @@ objectclass: top
 
 dn: cn=pi_user45_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user45_org1_test
+owneruid: user45_org1_test
 gidnumber: 10243
 memberuid: user45_org1_test
 objectclass: unityGroup
@@ -10519,6 +10522,7 @@ objectclass: top
 
 dn: cn=pi_user51_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user51_org3_test
+owneruid: user51_org3_test
 gidnumber: 10222
 memberuid: user51_org3_test
 memberuid: user934_org3_test
@@ -10528,6 +10532,7 @@ objectclass: top
 
 dn: cn=pi_user52_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user52_org1_test
+owneruid: user52_org1_test
 gidnumber: 10151
 memberuid: user52_org1_test
 memberuid: user1178_org1_test
@@ -10547,6 +10552,7 @@ objectclass: top
 
 dn: cn=pi_user57_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user57_org2_test
+owneruid: user57_org2_test
 gidnumber: 10132
 memberuid: user57_org2_test
 memberuid: user67_org2_test
@@ -10556,6 +10562,7 @@ objectclass: top
 
 dn: cn=pi_user66_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user66_org2_test
+owneruid: user66_org2_test
 gidnumber: 10199
 memberuid: user66_org2_test
 objectclass: unityGroup
@@ -10564,6 +10571,7 @@ objectclass: top
 
 dn: cn=pi_user70_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user70_org1_test
+owneruid: user70_org1_test
 gidnumber: 10082
 memberuid: user70_org1_test
 memberuid: user1287_org1_test
@@ -10579,6 +10587,7 @@ objectclass: top
 
 dn: cn=pi_user72_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user72_org3_test
+owneruid: user72_org3_test
 gidnumber: 10223
 memberuid: user72_org3_test
 memberuid: user1223_org3_test
@@ -10588,6 +10597,7 @@ objectclass: top
 
 dn: cn=pi_user78_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user78_org1_test
+owneruid: user78_org1_test
 gidnumber: 10157
 memberuid: user78_org1_test
 memberuid: user526_org1_test
@@ -10597,6 +10607,7 @@ objectclass: top
 
 dn: cn=pi_user93_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user93_org1_test
+owneruid: user93_org1_test
 gidnumber: 10101
 memberuid: user93_org1_test
 objectclass: unityGroup
@@ -10605,6 +10616,7 @@ objectclass: top
 
 dn: cn=pi_user94_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user94_org1_test
+owneruid: user94_org1_test
 gidnumber: 10088
 memberuid: user94_org1_test
 memberuid: user836_org1_test
@@ -10621,6 +10633,7 @@ objectclass: top
 
 dn: cn=pi_user113_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user113_org1_test
+owneruid: user113_org1_test
 gidnumber: 10099
 memberuid: user113_org1_test
 memberuid: user272_org1_test
@@ -10630,6 +10643,7 @@ objectclass: top
 
 dn: cn=pi_user126_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user126_org2_test
+owneruid: user126_org2_test
 gidnumber: 10077
 memberuid: user126_org2_test
 memberuid: user321_org2_test
@@ -10643,6 +10657,7 @@ objectclass: top
 
 dn: cn=pi_user130_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user130_org1_test
+owneruid: user130_org1_test
 gidnumber: 10008
 memberuid: user130_org1_test
 memberuid: user427_org1_test
@@ -10656,6 +10671,7 @@ objectclass: top
 
 dn: cn=pi_user135_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user135_org1_test
+owneruid: user135_org1_test
 gidnumber: 10063
 memberuid: user135_org1_test
 memberuid: user860_org1_test
@@ -10666,6 +10682,7 @@ objectclass: top
 
 dn: cn=pi_user138_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user138_org3_test
+owneruid: user138_org3_test
 gidnumber: 10116
 memberuid: user138_org3_test
 memberuid: user512_org3_test
@@ -10678,6 +10695,7 @@ objectclass: top
 
 dn: cn=pi_user149_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user149_org1_test
+owneruid: user149_org1_test
 gidnumber: 10071
 memberuid: user149_org1_test
 memberuid: user263_org1_test
@@ -10687,6 +10705,7 @@ objectclass: top
 
 dn: cn=pi_user150_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user150_org1_test
+owneruid: user150_org1_test
 gidnumber: 10254
 memberuid: user150_org1_test
 memberuid: user1250_org1_test
@@ -10697,6 +10716,7 @@ objectclass: top
 
 dn: cn=pi_user162_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user162_org1_test
+owneruid: user162_org1_test
 gidnumber: 10228
 memberuid: user162_org1_test
 objectclass: unityGroup
@@ -10705,6 +10725,7 @@ objectclass: top
 
 dn: cn=pi_user163_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user163_org1_test
+owneruid: user163_org1_test
 gidnumber: 10179
 memberuid: user163_org1_test
 memberuid: user300_org1_test
@@ -10715,6 +10736,7 @@ objectclass: top
 
 dn: cn=pi_user166_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user166_org2_test
+owneruid: user166_org2_test
 gidnumber: 10165
 memberuid: user166_org2_test
 objectclass: unityGroup
@@ -10723,6 +10745,7 @@ objectclass: top
 
 dn: cn=pi_user167_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user167_org1_test
+owneruid: user167_org1_test
 gidnumber: 10009
 memberuid: user167_org1_test
 memberuid: user1097_org1_test
@@ -10733,6 +10756,7 @@ objectclass: top
 
 dn: cn=pi_user176_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user176_org2_test
+owneruid: user176_org2_test
 gidnumber: 10216
 memberuid: user176_org2_test
 objectclass: unityGroup
@@ -10741,6 +10765,7 @@ objectclass: top
 
 dn: cn=pi_user181_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user181_org1_test
+owneruid: user181_org1_test
 gidnumber: 10245
 memberuid: user181_org1_test
 memberuid: user909_org1_test
@@ -10750,6 +10775,7 @@ objectclass: top
 
 dn: cn=pi_user182_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user182_org1_test
+owneruid: user182_org1_test
 gidnumber: 10150
 memberuid: user182_org1_test
 memberuid: user752_org1_test
@@ -10760,6 +10786,7 @@ objectclass: top
 
 dn: cn=pi_user187_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user187_org1_test
+owneruid: user187_org1_test
 gidnumber: 10103
 memberuid: user187_org1_test
 memberuid: user99_org1_test
@@ -10772,6 +10799,7 @@ objectclass: top
 
 dn: cn=pi_user188_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user188_org1_test
+owneruid: user188_org1_test
 gidnumber: 10143
 memberuid: user188_org1_test
 objectclass: unityGroup
@@ -10780,6 +10808,7 @@ objectclass: top
 
 dn: cn=pi_user190_org000000007_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user190_org000000007_test
+owneruid: user190_org000000007_test
 gidnumber: 10260
 memberuid: user190_org000000007_test
 memberuid: user211_org000000007_test
@@ -10790,6 +10819,7 @@ objectclass: top
 
 dn: cn=pi_user191_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user191_org2_test
+owneruid: user191_org2_test
 gidnumber: 10181
 memberuid: user191_org2_test
 memberuid: user1113_org2_test
@@ -10799,6 +10829,7 @@ objectclass: top
 
 dn: cn=pi_user194_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user194_org1_test
+owneruid: user194_org1_test
 gidnumber: 10079
 memberuid: user194_org1_test
 memberuid: user360_org1_test
@@ -10818,6 +10849,7 @@ objectclass: top
 
 dn: cn=pi_user5_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user5_org2_test
+owneruid: user5_org2_test
 gidnumber: 10135
 memberuid: user5_org2_test
 objectclass: unityGroup
@@ -10826,6 +10858,7 @@ objectclass: top
 
 dn: cn=pi_user197_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user197_org3_test
+owneruid: user197_org3_test
 gidnumber: 10230
 memberuid: user197_org3_test
 memberuid: user639_org3_test
@@ -10836,6 +10869,7 @@ objectclass: top
 
 dn: cn=pi_user198_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user198_org1_test
+owneruid: user198_org1_test
 gidnumber: 10154
 memberuid: user198_org1_test
 memberuid: user1199_org1_test
@@ -10849,6 +10883,7 @@ objectclass: top
 
 dn: cn=pi_user200_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user200_org2_test
+owneruid: user200_org2_test
 gidnumber: 10275
 memberuid: user200_org2_test
 memberuid: user662_org2_test
@@ -10858,6 +10893,7 @@ objectclass: top
 
 dn: cn=pi_user201_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user201_org1_test
+owneruid: user201_org1_test
 gidnumber: 10010
 memberuid: user201_org1_test
 objectclass: unityGroup
@@ -10866,6 +10902,7 @@ objectclass: top
 
 dn: cn=pi_user205_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user205_org1_test
+owneruid: user205_org1_test
 gidnumber: 10274
 memberuid: user205_org1_test
 objectclass: unityGroup
@@ -10874,6 +10911,7 @@ objectclass: top
 
 dn: cn=pi_user206_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user206_org1_test
+owneruid: user206_org1_test
 gidnumber: 10048
 memberuid: user206_org1_test
 memberuid: user769_org1_test
@@ -10887,6 +10925,7 @@ objectclass: top
 
 dn: cn=pi_user207_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user207_org1_test
+owneruid: user207_org1_test
 gidnumber: 10220
 memberuid: user207_org1_test
 objectclass: unityGroup
@@ -10895,6 +10934,7 @@ objectclass: top
 
 dn: cn=pi_user212_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user212_org1_test
+owneruid: user212_org1_test
 gidnumber: 10074
 memberuid: user212_org1_test
 memberuid: user793_org1_test
@@ -10910,6 +10950,7 @@ objectclass: top
 
 dn: cn=pi_user214_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user214_org1_test
+owneruid: user214_org1_test
 gidnumber: 10145
 memberuid: user214_org1_test
 objectclass: unityGroup
@@ -10918,6 +10959,7 @@ objectclass: top
 
 dn: cn=pi_user216_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user216_org1_test
+owneruid: user216_org1_test
 gidnumber: 10005
 memberuid: user216_org1_test
 memberuid: user340_org1_test
@@ -10934,6 +10976,7 @@ objectclass: top
 
 dn: cn=pi_user219_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user219_org1_test
+owneruid: user219_org1_test
 gidnumber: 10012
 memberuid: user219_org1_test
 memberuid: user645_org1_test
@@ -10946,6 +10989,7 @@ objectclass: top
 
 dn: cn=pi_user226_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user226_org3_test
+owneruid: user226_org3_test
 gidnumber: 10164
 memberuid: user226_org3_test
 objectclass: unityGroup
@@ -10954,6 +10998,7 @@ objectclass: top
 
 dn: cn=pi_user9_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user9_org3_test
+owneruid: user9_org3_test
 gidnumber: 10094
 objectclass: unityGroup
 objectclass: posixGroup
@@ -10963,6 +11008,7 @@ manageruid: user12_org1_test
 
 dn: cn=pi_user10_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user10_org1_test
+owneruid: user10_org1_test
 gidnumber: 2257
 objectclass: unityGroup
 objectclass: posixGroup
@@ -10971,6 +11017,7 @@ isDisabled: TRUE
 
 dn: cn=pi_user242_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user242_org1_test
+owneruid: user242_org1_test
 gidnumber: 10052
 memberuid: user242_org1_test
 objectclass: unityGroup
@@ -10979,6 +11026,7 @@ objectclass: top
 
 dn: cn=pi_user247_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user247_org1_test
+owneruid: user247_org1_test
 gidnumber: 10126
 memberuid: user247_org1_test
 memberuid: user178_org1_test
@@ -10988,6 +11036,7 @@ objectclass: top
 
 dn: cn=pi_user252_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user252_org1_test
+owneruid: user252_org1_test
 gidnumber: 10261
 memberuid: user252_org1_test
 memberuid: user482_org1_test
@@ -11000,6 +11049,7 @@ objectclass: top
 
 dn: cn=pi_user253_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user253_org1_test
+owneruid: user253_org1_test
 gidnumber: 10013
 memberuid: user253_org1_test
 objectclass: unityGroup
@@ -11008,6 +11058,7 @@ objectclass: top
 
 dn: cn=pi_user256_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user256_org1_test
+owneruid: user256_org1_test
 gidnumber: 10006
 memberuid: user256_org1_test
 memberuid: user1247_org1_test
@@ -11033,6 +11084,7 @@ objectclass: top
 
 dn: cn=pi_user264_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user264_org1_test
+owneruid: user264_org1_test
 gidnumber: 10073
 memberuid: user264_org1_test
 objectclass: unityGroup
@@ -11041,6 +11093,7 @@ objectclass: top
 
 dn: cn=pi_user266_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user266_org1_test
+owneruid: user266_org1_test
 gidnumber: 10162
 memberuid: user266_org1_test
 memberuid: user111_org1_test
@@ -11050,6 +11103,7 @@ objectclass: top
 
 dn: cn=pi_user268_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user268_org1_test
+owneruid: user268_org1_test
 gidnumber: 10239
 memberuid: user268_org1_test
 objectclass: unityGroup
@@ -11058,6 +11112,7 @@ objectclass: top
 
 dn: cn=pi_user274_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user274_org2_test
+owneruid: user274_org2_test
 gidnumber: 10283
 memberuid: user274_org2_test
 objectclass: unityGroup
@@ -11066,6 +11121,7 @@ objectclass: top
 
 dn: cn=pi_user277_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user277_org1_test
+owneruid: user277_org1_test
 gidnumber: 10014
 memberuid: user277_org1_test
 memberuid: user978_org1_test
@@ -11078,6 +11134,7 @@ objectclass: top
 
 dn: cn=pi_user278_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user278_org3_test
+owneruid: user278_org3_test
 gidnumber: 10180
 memberuid: user278_org3_test
 memberuid: user20_org3_test
@@ -11087,6 +11144,7 @@ objectclass: top
 
 dn: cn=pi_user288_org000000007_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user288_org000000007_test
+owneruid: user288_org000000007_test
 gidnumber: 10234
 memberuid: user288_org000000007_test
 objectclass: unityGroup
@@ -11095,6 +11153,7 @@ objectclass: top
 
 dn: cn=pi_user291_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user291_org1_test
+owneruid: user291_org1_test
 gidnumber: 10201
 memberuid: user291_org1_test
 memberuid: user473_org1_test
@@ -11106,6 +11165,7 @@ objectclass: top
 
 dn: cn=pi_user292_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user292_org2_test
+owneruid: user292_org2_test
 gidnumber: 10229
 memberuid: user292_org2_test
 objectclass: unityGroup
@@ -11114,6 +11174,7 @@ objectclass: top
 
 dn: cn=pi_user295_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user295_org3_test
+owneruid: user295_org3_test
 gidnumber: 10277
 memberuid: user295_org3_test
 objectclass: unityGroup
@@ -11122,6 +11183,7 @@ objectclass: top
 
 dn: cn=pi_user303_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user303_org1_test
+owneruid: user303_org1_test
 gidnumber: 10209
 memberuid: user303_org1_test
 memberuid: user365_org1_test
@@ -11132,6 +11194,7 @@ objectclass: top
 
 dn: cn=pi_user304_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user304_org1_test
+owneruid: user304_org1_test
 gidnumber: 10248
 memberuid: user304_org1_test
 objectclass: unityGroup
@@ -11140,6 +11203,7 @@ objectclass: top
 
 dn: cn=pi_user309_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user309_org1_test
+owneruid: user309_org1_test
 gidnumber: 10015
 memberuid: user309_org1_test
 memberuid: user58_org1_test
@@ -11152,6 +11216,7 @@ objectclass: top
 
 dn: cn=pi_user312_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user312_org1_test
+owneruid: user312_org1_test
 gidnumber: 10155
 memberuid: user312_org1_test
 memberuid: user794_org1_test
@@ -11163,6 +11228,7 @@ objectclass: top
 
 dn: cn=pi_user315_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user315_org2_test
+owneruid: user315_org2_test
 gidnumber: 10112
 memberuid: user315_org2_test
 memberuid: user392_org2_test
@@ -11173,6 +11239,7 @@ objectclass: top
 
 dn: cn=pi_user326_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user326_org3_test
+owneruid: user326_org3_test
 gidnumber: 10173
 memberuid: user326_org3_test
 memberuid: user883_org3_test
@@ -11182,6 +11249,7 @@ objectclass: top
 
 dn: cn=pi_user329_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user329_org1_test
+owneruid: user329_org1_test
 gidnumber: 10136
 memberuid: user329_org1_test
 memberuid: user46_org1_test
@@ -11192,6 +11260,7 @@ objectclass: top
 
 dn: cn=pi_user331_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user331_org1_test
+owneruid: user331_org1_test
 gidnumber: 10227
 memberuid: user331_org1_test
 objectclass: unityGroup
@@ -11200,6 +11269,7 @@ objectclass: top
 
 dn: cn=pi_user336_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user336_org1_test
+owneruid: user336_org1_test
 gidnumber: 10137
 memberuid: user336_org1_test
 memberuid: user478_org1_test
@@ -11209,6 +11279,7 @@ objectclass: top
 
 dn: cn=pi_user338_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user338_org1_test
+owneruid: user338_org1_test
 gidnumber: 10267
 memberuid: user338_org1_test
 memberuid: user1149_org1_test
@@ -11218,6 +11289,7 @@ objectclass: top
 
 dn: cn=pi_user342_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user342_org1_test
+owneruid: user342_org1_test
 gidnumber: 10090
 memberuid: user342_org1_test
 memberuid: user1188_org1_test
@@ -11233,6 +11305,7 @@ objectclass: top
 
 dn: cn=pi_user345_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user345_org1_test
+owneruid: user345_org1_test
 gidnumber: 10186
 memberuid: user345_org1_test
 memberuid: user1084_org1_test
@@ -11242,6 +11315,7 @@ objectclass: top
 
 dn: cn=pi_user346_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user346_org2_test
+owneruid: user346_org2_test
 gidnumber: 10246
 memberuid: user346_org2_test
 objectclass: unityGroup
@@ -11250,6 +11324,7 @@ objectclass: top
 
 dn: cn=pi_user347_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user347_org2_test
+owneruid: user347_org2_test
 gidnumber: 10081
 memberuid: user347_org2_test
 memberuid: user24_org2_test
@@ -11259,6 +11334,7 @@ objectclass: top
 
 dn: cn=pi_user354_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user354_org1_test
+owneruid: user354_org1_test
 gidnumber: 10016
 memberuid: user354_org1_test
 objectclass: unityGroup
@@ -11267,6 +11343,7 @@ objectclass: top
 
 dn: cn=pi_user371_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user371_org1_test
+owneruid: user371_org1_test
 gidnumber: 10066
 memberuid: user371_org1_test
 memberuid: user332_org1_test
@@ -11282,6 +11359,7 @@ objectclass: top
 
 dn: cn=pi_user372_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user372_org1_test
+owneruid: user372_org1_test
 gidnumber: 10053
 memberuid: user372_org1_test
 objectclass: unityGroup
@@ -11290,6 +11368,7 @@ objectclass: top
 
 dn: cn=pi_user373_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user373_org1_test
+owneruid: user373_org1_test
 gidnumber: 10065
 memberuid: user373_org1_test
 memberuid: user128_org1_test
@@ -11304,6 +11383,7 @@ objectclass: top
 
 dn: cn=pi_user382_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user382_org1_test
+owneruid: user382_org1_test
 gidnumber: 10219
 memberuid: user382_org1_test
 memberuid: user590_org1_test
@@ -11313,6 +11393,7 @@ objectclass: top
 
 dn: cn=pi_user386_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user386_org1_test
+owneruid: user386_org1_test
 gidnumber: 10197
 memberuid: user386_org1_test
 objectclass: unityGroup
@@ -11321,6 +11402,7 @@ objectclass: top
 
 dn: cn=pi_user391_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user391_org1_test
+owneruid: user391_org1_test
 gidnumber: 10098
 memberuid: user391_org1_test
 memberuid: user63_org1_test
@@ -11331,6 +11413,7 @@ objectclass: top
 
 dn: cn=pi_user393_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user393_org1_test
+owneruid: user393_org1_test
 gidnumber: 10017
 memberuid: user393_org1_test
 objectclass: unityGroup
@@ -11339,6 +11422,7 @@ objectclass: top
 
 dn: cn=pi_user395_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user395_org1_test
+owneruid: user395_org1_test
 gidnumber: 10122
 memberuid: user395_org1_test
 memberuid: user993_org1_test
@@ -11348,6 +11432,7 @@ objectclass: top
 
 dn: cn=pi_user398_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user398_org1_test
+owneruid: user398_org1_test
 gidnumber: 10169
 memberuid: user398_org1_test
 memberuid: user394_org1_test
@@ -11357,6 +11442,7 @@ objectclass: top
 
 dn: cn=pi_user400_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user400_org1_test
+owneruid: user400_org1_test
 gidnumber: 10170
 memberuid: user400_org1_test
 memberuid: user712_org1_test
@@ -11368,6 +11454,7 @@ objectclass: top
 
 dn: cn=pi_user404_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user404_org3_test
+owneruid: user404_org3_test
 gidnumber: 10152
 memberuid: user404_org3_test
 memberuid: user145_org3_test
@@ -11377,6 +11464,7 @@ objectclass: top
 
 dn: cn=pi_user407_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user407_org1_test
+owneruid: user407_org1_test
 gidnumber: 10238
 memberuid: user407_org1_test
 objectclass: unityGroup
@@ -11385,6 +11473,7 @@ objectclass: top
 
 dn: cn=pi_user415_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user415_org3_test
+owneruid: user415_org3_test
 gidnumber: 10002
 memberuid: user415_org3_test
 memberuid: user261_org3_test
@@ -11396,6 +11485,7 @@ objectclass: top
 
 dn: cn=pi_user416_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user416_org1_test
+owneruid: user416_org1_test
 gidnumber: 10279
 memberuid: user416_org1_test
 memberuid: user952_org1_test
@@ -11405,6 +11495,7 @@ objectclass: top
 
 dn: cn=pi_user420_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user420_org1_test
+owneruid: user420_org1_test
 gidnumber: 10147
 memberuid: user420_org1_test
 memberuid: user977_org1_test
@@ -11414,6 +11505,7 @@ objectclass: top
 
 dn: cn=pi_user423_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user423_org1_test
+owneruid: user423_org1_test
 gidnumber: 10252
 memberuid: user423_org1_test
 memberuid: user1211_org1_test
@@ -11423,6 +11515,7 @@ objectclass: top
 
 dn: cn=pi_user424_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user424_org2_test
+owneruid: user424_org2_test
 gidnumber: 10040
 memberuid: user424_org2_test
 memberuid: user1108_org2_test
@@ -11439,6 +11532,7 @@ objectclass: top
 
 dn: cn=pi_user426_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user426_org3_test
+owneruid: user426_org3_test
 gidnumber: 10177
 memberuid: user426_org3_test
 memberuid: user112_org3_test
@@ -11450,6 +11544,7 @@ objectclass: top
 
 dn: cn=pi_user432_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user432_org2_test
+owneruid: user432_org2_test
 gidnumber: 10212
 memberuid: user432_org2_test
 memberuid: user595_org2_test
@@ -11459,6 +11554,7 @@ objectclass: top
 
 dn: cn=pi_user433_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user433_org1_test
+owneruid: user433_org1_test
 gidnumber: 10156
 memberuid: user433_org1_test
 memberuid: user209_org1_test
@@ -11468,6 +11564,7 @@ objectclass: top
 
 dn: cn=pi_user436_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user436_org2_test
+owneruid: user436_org2_test
 gidnumber: 10236
 memberuid: user436_org2_test
 objectclass: unityGroup
@@ -11476,6 +11573,7 @@ objectclass: top
 
 dn: cn=pi_user438_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user438_org1_test
+owneruid: user438_org1_test
 gidnumber: 10001
 memberuid: user341_org1_test
 memberuid: user438_org1_test
@@ -11492,6 +11590,7 @@ objectclass: top
 
 dn: cn=pi_user439_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user439_org2_test
+owneruid: user439_org2_test
 gidnumber: 10205
 memberuid: user439_org2_test
 memberuid: user412_org2_test
@@ -11503,6 +11602,7 @@ objectclass: top
 
 dn: cn=pi_user440_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user440_org1_test
+owneruid: user440_org1_test
 gidnumber: 10060
 memberuid: user440_org1_test
 memberuid: user89_org1_test
@@ -11514,6 +11614,7 @@ objectclass: top
 
 dn: cn=pi_user442_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user442_org1_test
+owneruid: user442_org1_test
 gidnumber: 10263
 memberuid: user442_org1_test
 memberuid: user700_org1_test
@@ -11524,6 +11625,7 @@ objectclass: top
 
 dn: cn=pi_user446_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user446_org1_test
+owneruid: user446_org1_test
 gidnumber: 10047
 memberuid: user446_org1_test
 memberuid: user1079_org1_test
@@ -11546,6 +11648,7 @@ objectclass: top
 
 dn: cn=pi_user452_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user452_org1_test
+owneruid: user452_org1_test
 gidnumber: 10003
 memberuid: user452_org1_test
 memberuid: user316_org1_test
@@ -11556,6 +11659,7 @@ objectclass: top
 
 dn: cn=pi_user453_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user453_org1_test
+owneruid: user453_org1_test
 gidnumber: 10118
 memberuid: user453_org1_test
 memberuid: user1210_org1_test
@@ -11566,6 +11670,7 @@ objectclass: top
 
 dn: cn=pi_user458_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user458_org1_test
+owneruid: user458_org1_test
 gidnumber: 10089
 memberuid: user458_org1_test
 memberuid: user310_org1_test
@@ -11582,6 +11687,7 @@ objectclass: top
 
 dn: cn=pi_user460_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user460_org1_test
+owneruid: user460_org1_test
 gidnumber: 10172
 memberuid: user460_org1_test
 memberuid: user172_org1_test
@@ -11591,6 +11697,7 @@ objectclass: top
 
 dn: cn=pi_user466_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user466_org2_test
+owneruid: user466_org2_test
 gidnumber: 10166
 memberuid: user466_org2_test
 objectclass: unityGroup
@@ -11599,6 +11706,7 @@ objectclass: top
 
 dn: cn=pi_user467_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user467_org2_test
+owneruid: user467_org2_test
 gidnumber: 10129
 memberuid: user467_org2_test
 memberuid: user723_org2_test
@@ -11609,6 +11717,7 @@ objectclass: top
 
 dn: cn=pi_user480_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user480_org1_test
+owneruid: user480_org1_test
 gidnumber: 10168
 memberuid: user480_org1_test
 memberuid: user900_org1_test
@@ -11618,6 +11727,7 @@ objectclass: top
 
 dn: cn=pi_user483_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user483_org1_test
+owneruid: user483_org1_test
 gidnumber: 10141
 memberuid: user483_org1_test
 memberuid: user762_org1_test
@@ -11657,6 +11767,7 @@ objectclass: top
 
 dn: cn=pi_user487_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user487_org2_test
+owneruid: user487_org2_test
 gidnumber: 10194
 memberuid: user487_org2_test
 memberuid: user479_org2_test
@@ -11674,6 +11785,7 @@ objectclass: top
 
 dn: cn=pi_user496_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user496_org1_test
+owneruid: user496_org1_test
 gidnumber: 10087
 memberuid: user496_org1_test
 memberuid: user682_org1_test
@@ -11706,6 +11818,7 @@ objectclass: top
 
 dn: cn=pi_user500_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user500_org1_test
+owneruid: user500_org1_test
 gidnumber: 10093
 memberuid: user500_org1_test
 memberuid: user563_org1_test
@@ -11730,6 +11843,7 @@ objectclass: top
 
 dn: cn=pi_user502_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user502_org1_test
+owneruid: user502_org1_test
 gidnumber: 10203
 memberuid: user502_org1_test
 memberuid: user1072_org1_test
@@ -11741,6 +11855,7 @@ objectclass: top
 
 dn: cn=pi_user507_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user507_org2_test
+owneruid: user507_org2_test
 gidnumber: 10110
 memberuid: user507_org2_test
 memberuid: user104_org2_test
@@ -11755,6 +11870,7 @@ objectclass: top
 
 dn: cn=pi_user513_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user513_org1_test
+owneruid: user513_org1_test
 gidnumber: 10108
 memberuid: user513_org1_test
 objectclass: unityGroup
@@ -11763,6 +11879,7 @@ objectclass: top
 
 dn: cn=pi_user517_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user517_org1_test
+owneruid: user517_org1_test
 gidnumber: 10251
 memberuid: user517_org1_test
 memberuid: user1253_org1_test
@@ -11773,6 +11890,7 @@ objectclass: top
 
 dn: cn=pi_user519_org000000007_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user519_org000000007_test
+owneruid: user519_org000000007_test
 gidnumber: 10259
 memberuid: user519_org000000007_test
 objectclass: unityGroup
@@ -11781,6 +11899,7 @@ objectclass: top
 
 dn: cn=pi_user528_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user528_org1_test
+owneruid: user528_org1_test
 gidnumber: 10104
 memberuid: user528_org1_test
 memberuid: user799_org1_test
@@ -11790,6 +11909,7 @@ objectclass: top
 
 dn: cn=pi_user530_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user530_org1_test
+owneruid: user530_org1_test
 gidnumber: 10095
 memberuid: user530_org1_test
 memberuid: user1222_org1_test
@@ -11802,6 +11922,7 @@ objectclass: top
 
 dn: cn=pi_user532_org000000007_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user532_org000000007_test
+owneruid: user532_org000000007_test
 gidnumber: 10174
 memberuid: user532_org000000007_test
 objectclass: unityGroup
@@ -11810,6 +11931,7 @@ objectclass: top
 
 dn: cn=pi_user534_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user534_org1_test
+owneruid: user534_org1_test
 gidnumber: 10085
 memberuid: user534_org1_test
 memberuid: user619_org1_test
@@ -11823,6 +11945,7 @@ objectclass: top
 
 dn: cn=pi_user543_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user543_org1_test
+owneruid: user543_org1_test
 gidnumber: 10111
 memberuid: user543_org1_test
 memberuid: user621_org1_test
@@ -11885,6 +12008,7 @@ objectclass: top
 
 dn: cn=pi_user1_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1_org1_test
+owneruid: user1_org1_test
 gidnumber: 10000
 memberuid: user4_org1_test
 memberuid: user1_org1_test
@@ -11905,6 +12029,7 @@ objectclass: top
 
 dn: cn=pi_user546_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user546_org1_test
+owneruid: user546_org1_test
 gidnumber: 10193
 memberuid: user546_org1_test
 memberuid: user103_org1_test
@@ -11914,6 +12039,7 @@ objectclass: top
 
 dn: cn=pi_user550_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user550_org1_test
+owneruid: user550_org1_test
 gidnumber: 10187
 memberuid: user550_org1_test
 memberuid: user1107_org1_test
@@ -11923,6 +12049,7 @@ objectclass: top
 
 dn: cn=pi_user551_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user551_org1_test
+owneruid: user551_org1_test
 gidnumber: 10019
 memberuid: user551_org1_test
 memberuid: user1267_org1_test
@@ -11937,6 +12064,7 @@ objectclass: top
 
 dn: cn=pi_user554_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user554_org2_test
+owneruid: user554_org2_test
 gidnumber: 10241
 memberuid: user554_org2_test
 objectclass: unityGroup
@@ -11945,6 +12073,7 @@ objectclass: top
 
 dn: cn=pi_user559_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user559_org1_test
+owneruid: user559_org1_test
 gidnumber: 10004
 memberuid: user559_org1_test
 memberuid: user509_org1_test
@@ -11954,6 +12083,7 @@ objectclass: top
 
 dn: cn=pi_user560_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user560_org1_test
+owneruid: user560_org1_test
 gidnumber: 10057
 memberuid: user560_org1_test
 memberuid: user875_org1_test
@@ -11964,6 +12094,7 @@ objectclass: top
 
 dn: cn=pi_user561_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user561_org1_test
+owneruid: user561_org1_test
 gidnumber: 10054
 memberuid: user561_org1_test
 memberuid: user932_org1_test
@@ -11974,6 +12105,7 @@ objectclass: top
 
 dn: cn=pi_user564_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user564_org1_test
+owneruid: user564_org1_test
 gidnumber: 10123
 memberuid: user564_org1_test
 objectclass: unityGroup
@@ -11982,6 +12114,7 @@ objectclass: top
 
 dn: cn=pi_user565_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user565_org1_test
+owneruid: user565_org1_test
 gidnumber: 10018
 memberuid: user565_org1_test
 memberuid: user215_org1_test
@@ -12016,6 +12149,7 @@ objectclass: top
 
 dn: cn=pi_user569_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user569_org1_test
+owneruid: user569_org1_test
 gidnumber: 10106
 memberuid: user569_org1_test
 memberuid: user875_org1_test
@@ -12033,6 +12167,7 @@ objectclass: top
 
 dn: cn=pi_user575_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user575_org1_test
+owneruid: user575_org1_test
 gidnumber: 10092
 memberuid: user575_org1_test
 memberuid: user863_org1_test
@@ -12042,6 +12177,7 @@ objectclass: top
 
 dn: cn=pi_user580_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user580_org1_test
+owneruid: user580_org1_test
 gidnumber: 10119
 memberuid: user580_org1_test
 objectclass: unityGroup
@@ -12050,6 +12186,7 @@ objectclass: top
 
 dn: cn=pi_user582_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user582_org1_test
+owneruid: user582_org1_test
 gidnumber: 10051
 memberuid: user582_org1_test
 objectclass: unityGroup
@@ -12058,6 +12195,7 @@ objectclass: top
 
 dn: cn=pi_user586_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user586_org1_test
+owneruid: user586_org1_test
 gidnumber: 10020
 memberuid: user586_org1_test
 objectclass: unityGroup
@@ -12066,6 +12204,7 @@ objectclass: top
 
 dn: cn=pi_user591_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user591_org1_test
+owneruid: user591_org1_test
 gidnumber: 10139
 memberuid: user591_org1_test
 memberuid: user1104_org1_test
@@ -12078,6 +12217,7 @@ objectclass: top
 
 dn: cn=pi_user592_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user592_org2_test
+owneruid: user592_org2_test
 gidnumber: 10235
 memberuid: user592_org2_test
 memberuid: user410_org2_test
@@ -12087,6 +12227,7 @@ objectclass: top
 
 dn: cn=pi_user601_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user601_org1_test
+owneruid: user601_org1_test
 gidnumber: 10080
 memberuid: user601_org1_test
 memberuid: user86_org1_test
@@ -12110,6 +12251,7 @@ objectclass: top
 
 dn: cn=pi_user608_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user608_org1_test
+owneruid: user608_org1_test
 gidnumber: 10070
 memberuid: user608_org1_test
 objectclass: unityGroup
@@ -12118,6 +12260,7 @@ objectclass: top
 
 dn: cn=pi_user615_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user615_org1_test
+owneruid: user615_org1_test
 gidnumber: 10021
 memberuid: user615_org1_test
 memberuid: user660_org1_test
@@ -12131,6 +12274,7 @@ objectclass: top
 
 dn: cn=pi_user626_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user626_org1_test
+owneruid: user626_org1_test
 gidnumber: 10107
 memberuid: user626_org1_test
 objectclass: unityGroup
@@ -12139,6 +12283,7 @@ objectclass: top
 
 dn: cn=pi_user635_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user635_org1_test
+owneruid: user635_org1_test
 gidnumber: 10175
 memberuid: user635_org1_test
 objectclass: unityGroup
@@ -12147,6 +12292,7 @@ objectclass: top
 
 dn: cn=pi_user636_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user636_org2_test
+owneruid: user636_org2_test
 gidnumber: 10195
 memberuid: user636_org2_test
 memberuid: user694_org2_test
@@ -12156,6 +12302,7 @@ objectclass: top
 
 dn: cn=pi_user641_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user641_org1_test
+owneruid: user641_org1_test
 gidnumber: 10084
 memberuid: user641_org1_test
 memberuid: user239_org1_test
@@ -12167,6 +12314,7 @@ objectclass: top
 
 dn: cn=pi_user647_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user647_org1_test
+owneruid: user647_org1_test
 gidnumber: 10115
 memberuid: user647_org1_test
 memberuid: user739_org1_test
@@ -12177,6 +12325,7 @@ objectclass: top
 
 dn: cn=pi_user656_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user656_org1_test
+owneruid: user656_org1_test
 gidnumber: 10064
 memberuid: user656_org1_test
 memberuid: user80_org1_test
@@ -12186,6 +12335,7 @@ objectclass: top
 
 dn: cn=pi_user659_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user659_org1_test
+owneruid: user659_org1_test
 gidnumber: 10144
 memberuid: user659_org1_test
 memberuid: user265_org1_test
@@ -12195,6 +12345,7 @@ objectclass: top
 
 dn: cn=pi_user663_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user663_org2_test
+owneruid: user663_org2_test
 gidnumber: 10202
 memberuid: user663_org2_test
 objectclass: unityGroup
@@ -12203,6 +12354,7 @@ objectclass: top
 
 dn: cn=pi_user666_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user666_org1_test
+owneruid: user666_org1_test
 gidnumber: 10125
 memberuid: user666_org1_test
 memberuid: user495_org1_test
@@ -12215,6 +12367,7 @@ objectclass: top
 
 dn: cn=pi_user670_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user670_org1_test
+owneruid: user670_org1_test
 gidnumber: 10062
 memberuid: user670_org1_test
 memberuid: user195_org1_test
@@ -12224,6 +12377,7 @@ objectclass: top
 
 dn: cn=pi_user674_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user674_org1_test
+owneruid: user674_org1_test
 gidnumber: 10217
 memberuid: user674_org1_test
 memberuid: user680_org1_test
@@ -12233,6 +12387,7 @@ objectclass: top
 
 dn: cn=pi_user676_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user676_org1_test
+owneruid: user676_org1_test
 gidnumber: 10058
 memberuid: user676_org1_test
 memberuid: user137_org1_test
@@ -12246,6 +12401,7 @@ objectclass: top
 
 dn: cn=pi_user677_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user677_org1_test
+owneruid: user677_org1_test
 gidnumber: 10127
 memberuid: user677_org1_test
 memberuid: user1294_org1_test
@@ -12257,6 +12413,7 @@ objectclass: top
 
 dn: cn=pi_user681_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user681_org1_test
+owneruid: user681_org1_test
 gidnumber: 10042
 memberuid: user681_org1_test
 memberuid: user1066_org1_test
@@ -12283,6 +12440,7 @@ objectclass: top
 
 dn: cn=pi_user688_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user688_org1_test
+owneruid: user688_org1_test
 gidnumber: 10113
 memberuid: user688_org1_test
 memberuid: user374_org1_test
@@ -12299,6 +12457,7 @@ objectclass: top
 
 dn: cn=pi_user695_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user695_org2_test
+owneruid: user695_org2_test
 gidnumber: 10211
 memberuid: user695_org2_test
 memberuid: user705_org2_test
@@ -12309,6 +12468,7 @@ objectclass: top
 
 dn: cn=pi_user699_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user699_org1_test
+owneruid: user699_org1_test
 gidnumber: 10075
 memberuid: user699_org1_test
 memberuid: user665_org1_test
@@ -12319,6 +12479,7 @@ objectclass: top
 
 dn: cn=pi_user703_org11_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user703_org11_test
+owneruid: user703_org11_test
 gidnumber: 10207
 memberuid: user703_org11_test
 objectclass: unityGroup
@@ -12327,6 +12488,7 @@ objectclass: top
 
 dn: cn=pi_user714_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user714_org2_test
+owneruid: user714_org2_test
 gidnumber: 10044
 memberuid: user714_org2_test
 memberuid: user760_org2_test
@@ -12337,6 +12499,7 @@ objectclass: top
 
 dn: cn=pi_user717_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user717_org2_test
+owneruid: user717_org2_test
 gidnumber: 10200
 memberuid: user717_org2_test
 memberuid: user189_org2_test
@@ -12347,6 +12510,7 @@ objectclass: top
 
 dn: cn=pi_user720_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user720_org1_test
+owneruid: user720_org1_test
 gidnumber: 10161
 memberuid: user720_org1_test
 memberuid: user171_org1_test
@@ -12357,6 +12521,7 @@ objectclass: top
 
 dn: cn=pi_user722_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user722_org1_test
+owneruid: user722_org1_test
 gidnumber: 10091
 memberuid: user722_org1_test
 memberuid: user276_org1_test
@@ -12369,6 +12534,7 @@ objectclass: top
 
 dn: cn=pi_user724_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user724_org1_test
+owneruid: user724_org1_test
 gidnumber: 10045
 memberuid: user724_org1_test
 memberuid: user864_org1_test
@@ -12378,6 +12544,7 @@ objectclass: top
 
 dn: cn=pi_user725_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user725_org2_test
+owneruid: user725_org2_test
 gidnumber: 10198
 memberuid: user725_org2_test
 memberuid: user876_org2_test
@@ -12387,6 +12554,7 @@ objectclass: top
 
 dn: cn=pi_user727_org000000007_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user727_org000000007_test
+owneruid: user727_org000000007_test
 gidnumber: 10266
 memberuid: user727_org000000007_test
 memberuid: user1192_org000000007_test
@@ -12396,6 +12564,7 @@ objectclass: top
 
 dn: cn=pi_user730_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user730_org1_test
+owneruid: user730_org1_test
 gidnumber: 10072
 memberuid: user730_org1_test
 memberuid: user1120_org1_test
@@ -12410,6 +12579,7 @@ objectclass: top
 
 dn: cn=pi_user733_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user733_org1_test
+owneruid: user733_org1_test
 gidnumber: 10036
 memberuid: user733_org1_test
 memberuid: user852_org1_test
@@ -12422,6 +12592,7 @@ objectclass: top
 
 dn: cn=pi_user736_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user736_org1_test
+owneruid: user736_org1_test
 gidnumber: 10083
 memberuid: user736_org1_test
 memberuid: user116_org1_test
@@ -12476,6 +12647,7 @@ objectclass: top
 
 dn: cn=pi_user737_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user737_org1_test
+owneruid: user737_org1_test
 gidnumber: 10039
 memberuid: user737_org1_test
 objectclass: unityGroup
@@ -12484,6 +12656,7 @@ objectclass: top
 
 dn: cn=pi_user743_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user743_org1_test
+owneruid: user743_org1_test
 gidnumber: 10069
 memberuid: user743_org1_test
 memberuid: user1263_org1_test
@@ -12494,6 +12667,7 @@ objectclass: top
 
 dn: cn=pi_user744_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user744_org1_test
+owneruid: user744_org1_test
 gidnumber: 10022
 memberuid: user744_org1_test
 memberuid: user704_org1_test
@@ -12504,6 +12678,7 @@ objectclass: top
 
 dn: cn=pi_user751_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user751_org1_test
+owneruid: user751_org1_test
 gidnumber: 10130
 memberuid: user751_org1_test
 memberuid: user1093_org1_test
@@ -12523,6 +12698,7 @@ objectclass: top
 
 dn: cn=pi_user758_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user758_org1_test
+owneruid: user758_org1_test
 gidnumber: 10278
 memberuid: user758_org1_test
 objectclass: unityGroup
@@ -12531,6 +12707,7 @@ objectclass: top
 
 dn: cn=pi_user764_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user764_org1_test
+owneruid: user764_org1_test
 gidnumber: 10237
 memberuid: user764_org1_test
 objectclass: unityGroup
@@ -12539,6 +12716,7 @@ objectclass: top
 
 dn: cn=pi_user765_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user765_org1_test
+owneruid: user765_org1_test
 gidnumber: 10067
 memberuid: user765_org1_test
 memberuid: user42_org1_test
@@ -12561,6 +12739,7 @@ objectclass: top
 
 dn: cn=pi_user777_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user777_org3_test
+owneruid: user777_org3_test
 gidnumber: 10102
 memberuid: user777_org3_test
 memberuid: user204_org3_test
@@ -12574,6 +12753,7 @@ objectclass: top
 
 dn: cn=pi_user782_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user782_org1_test
+owneruid: user782_org1_test
 gidnumber: 10059
 memberuid: user782_org1_test
 memberuid: user1162_org1_test
@@ -12583,6 +12763,7 @@ objectclass: top
 
 dn: cn=pi_user783_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user783_org1_test
+owneruid: user783_org1_test
 gidnumber: 10167
 memberuid: user783_org1_test
 memberuid: user1057_org1_test
@@ -12593,6 +12774,7 @@ objectclass: top
 
 dn: cn=pi_user784_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user784_org1_test
+owneruid: user784_org1_test
 gidnumber: 10281
 memberuid: user784_org1_test
 memberuid: user228_org1_test
@@ -12602,6 +12784,7 @@ objectclass: top
 
 dn: cn=pi_user785_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user785_org1_test
+owneruid: user785_org1_test
 gidnumber: 10023
 memberuid: user785_org1_test
 memberuid: user244_org1_test
@@ -12615,6 +12798,7 @@ objectclass: top
 
 dn: cn=pi_user786_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user786_org1_test
+owneruid: user786_org1_test
 gidnumber: 10024
 memberuid: user786_org1_test
 memberuid: user1146_org1_test
@@ -12626,6 +12810,7 @@ objectclass: top
 
 dn: cn=pi_user788_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user788_org2_test
+owneruid: user788_org2_test
 gidnumber: 10191
 memberuid: user788_org2_test
 objectclass: unityGroup
@@ -12634,6 +12819,7 @@ objectclass: top
 
 dn: cn=pi_user789_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user789_org3_test
+owneruid: user789_org3_test
 gidnumber: 10000007
 memberuid: user789_org3_test
 memberuid: user105_org3_test
@@ -12648,6 +12834,7 @@ objectclass: top
 
 dn: cn=pi_user795_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user795_org1_test
+owneruid: user795_org1_test
 gidnumber: 10178
 memberuid: user795_org1_test
 objectclass: unityGroup
@@ -12656,6 +12843,7 @@ objectclass: top
 
 dn: cn=pi_user796_org11_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user796_org11_test
+owneruid: user796_org11_test
 gidnumber: 10133
 memberuid: user796_org11_test
 memberuid: user710_org11_test
@@ -12665,6 +12853,7 @@ objectclass: top
 
 dn: cn=pi_user798_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user798_org1_test
+owneruid: user798_org1_test
 gidnumber: 10035
 memberuid: user798_org1_test
 memberuid: user756_org1_test
@@ -12674,6 +12863,7 @@ objectclass: top
 
 dn: cn=pi_user801_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user801_org1_test
+owneruid: user801_org1_test
 gidnumber: 10271
 memberuid: user801_org1_test
 objectclass: unityGroup
@@ -12682,6 +12872,7 @@ objectclass: top
 
 dn: cn=pi_user803_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user803_org1_test
+owneruid: user803_org1_test
 gidnumber: 10025
 memberuid: user803_org1_test
 memberuid: user1058_org1_test
@@ -12691,6 +12882,7 @@ objectclass: top
 
 dn: cn=pi_user805_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user805_org3_test
+owneruid: user805_org3_test
 gidnumber: 10242
 memberuid: user805_org3_test
 memberuid: user154_org3_test
@@ -12702,6 +12894,7 @@ objectclass: top
 
 dn: cn=pi_user809_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user809_org2_test
+owneruid: user809_org2_test
 gidnumber: 10190
 memberuid: user809_org2_test
 objectclass: unityGroup
@@ -12710,6 +12903,7 @@ objectclass: top
 
 dn: cn=pi_user817_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user817_org1_test
+owneruid: user817_org1_test
 gidnumber: 10026
 memberuid: user817_org1_test
 memberuid: user1146_org1_test
@@ -12723,6 +12917,7 @@ objectclass: top
 
 dn: cn=pi_user830_org11_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user830_org11_test
+owneruid: user830_org11_test
 gidnumber: 10100
 memberuid: user830_org11_test
 objectclass: unityGroup
@@ -12731,6 +12926,7 @@ objectclass: top
 
 dn: cn=pi_user832_org14_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user832_org14_test
+owneruid: user832_org14_test
 gidnumber: 10268
 memberuid: user832_org14_test
 objectclass: unityGroup
@@ -12739,6 +12935,7 @@ objectclass: top
 
 dn: cn=pi_user833_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user833_org1_test
+owneruid: user833_org1_test
 gidnumber: 10218
 memberuid: user833_org1_test
 memberuid: user379_org1_test
@@ -12751,6 +12948,7 @@ objectclass: top
 
 dn: cn=pi_user834_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user834_org2_test
+owneruid: user834_org2_test
 gidnumber: 10224
 memberuid: user834_org2_test
 objectclass: unityGroup
@@ -12759,6 +12957,7 @@ objectclass: top
 
 dn: cn=pi_user848_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user848_org1_test
+owneruid: user848_org1_test
 gidnumber: 10225
 memberuid: user848_org1_test
 memberuid: user284_org1_test
@@ -12768,6 +12967,7 @@ objectclass: top
 
 dn: cn=pi_user849_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user849_org1_test
+owneruid: user849_org1_test
 gidnumber: 10160
 memberuid: user849_org1_test
 objectclass: unityGroup
@@ -12776,6 +12976,7 @@ objectclass: top
 
 dn: cn=pi_user857_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user857_org1_test
+owneruid: user857_org1_test
 gidnumber: 10027
 memberuid: user857_org1_test
 memberuid: user1036_org1_test
@@ -12786,6 +12987,7 @@ objectclass: top
 
 dn: cn=pi_user859_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user859_org1_test
+owneruid: user859_org1_test
 gidnumber: 10158
 memberuid: user859_org1_test
 memberuid: user96_org1_test
@@ -12795,6 +12997,7 @@ objectclass: top
 
 dn: cn=pi_user865_org000000007_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user865_org000000007_test
+owneruid: user865_org000000007_test
 gidnumber: 10221
 memberuid: user865_org000000007_test
 objectclass: unityGroup
@@ -12803,6 +13006,7 @@ objectclass: top
 
 dn: cn=pi_user868_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user868_org1_test
+owneruid: user868_org1_test
 gidnumber: 10076
 memberuid: user868_org1_test
 objectclass: unityGroup
@@ -12811,6 +13015,7 @@ objectclass: top
 
 dn: cn=pi_user870_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user870_org3_test
+owneruid: user870_org3_test
 gidnumber: 10233
 memberuid: user870_org3_test
 objectclass: unityGroup
@@ -12819,6 +13024,7 @@ objectclass: top
 
 dn: cn=pi_user872_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user872_org1_test
+owneruid: user872_org1_test
 gidnumber: 10038
 memberuid: user872_org1_test
 objectclass: unityGroup
@@ -12827,6 +13033,7 @@ objectclass: top
 
 dn: cn=pi_user873_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user873_org2_test
+owneruid: user873_org2_test
 gidnumber: 10142
 memberuid: user873_org2_test
 objectclass: unityGroup
@@ -12835,6 +13042,7 @@ objectclass: top
 
 dn: cn=pi_user875_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user875_org1_test
+owneruid: user875_org1_test
 gidnumber: 10185
 memberuid: user875_org1_test
 objectclass: unityGroup
@@ -12843,6 +13051,7 @@ objectclass: top
 
 dn: cn=pi_user877_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user877_org1_test
+owneruid: user877_org1_test
 gidnumber: 10028
 memberuid: user877_org1_test
 memberuid: user147_org1_test
@@ -12864,6 +13073,7 @@ objectclass: top
 
 dn: cn=pi_user878_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user878_org2_test
+owneruid: user878_org2_test
 gidnumber: 10214
 memberuid: user878_org2_test
 objectclass: unityGroup
@@ -12872,6 +13082,7 @@ objectclass: top
 
 dn: cn=pi_user879_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user879_org1_test
+owneruid: user879_org1_test
 gidnumber: 10037
 memberuid: user879_org1_test
 objectclass: unityGroup
@@ -12880,6 +13091,7 @@ objectclass: top
 
 dn: cn=pi_user881_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user881_org1_test
+owneruid: user881_org1_test
 gidnumber: 10086
 memberuid: user881_org1_test
 memberuid: user1203_org1_test
@@ -12890,6 +13102,7 @@ objectclass: top
 
 dn: cn=pi_user882_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user882_org1_test
+owneruid: user882_org1_test
 gidnumber: 10215
 memberuid: user882_org1_test
 memberuid: user941_org1_test
@@ -12900,6 +13113,7 @@ objectclass: top
 
 dn: cn=pi_user885_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user885_org1_test
+owneruid: user885_org1_test
 gidnumber: 10029
 memberuid: user885_org1_test
 memberuid: user742_org1_test
@@ -12910,6 +13124,7 @@ objectclass: top
 
 dn: cn=pi_user886_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user886_org1_test
+owneruid: user886_org1_test
 gidnumber: 10121
 memberuid: user886_org1_test
 objectclass: unityGroup
@@ -12918,6 +13133,7 @@ objectclass: top
 
 dn: cn=pi_user890_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user890_org3_test
+owneruid: user890_org3_test
 gidnumber: 10182
 memberuid: user890_org3_test
 objectclass: unityGroup
@@ -12926,6 +13142,7 @@ objectclass: top
 
 dn: cn=pi_user905_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user905_org1_test
+owneruid: user905_org1_test
 gidnumber: 10272
 memberuid: user905_org1_test
 objectclass: unityGroup
@@ -12934,6 +13151,7 @@ objectclass: top
 
 dn: cn=pi_user915_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user915_org1_test
+owneruid: user915_org1_test
 gidnumber: 10184
 memberuid: user915_org1_test
 memberuid: user431_org1_test
@@ -12943,6 +13161,7 @@ objectclass: top
 
 dn: cn=pi_user917_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user917_org1_test
+owneruid: user917_org1_test
 gidnumber: 10280
 memberuid: user917_org1_test
 objectclass: unityGroup
@@ -12951,6 +13170,7 @@ objectclass: top
 
 dn: cn=pi_user928_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user928_org1_test
+owneruid: user928_org1_test
 gidnumber: 10050
 memberuid: user928_org1_test
 objectclass: unityGroup
@@ -12959,6 +13179,7 @@ objectclass: top
 
 dn: cn=pi_user931_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user931_org1_test
+owneruid: user931_org1_test
 gidnumber: 10253
 memberuid: user931_org1_test
 objectclass: unityGroup
@@ -12967,6 +13188,7 @@ objectclass: top
 
 dn: cn=pi_user933_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user933_org2_test
+owneruid: user933_org2_test
 gidnumber: 10153
 memberuid: user933_org2_test
 memberuid: user122_org2_test
@@ -12978,6 +13200,7 @@ objectclass: top
 
 dn: cn=pi_user935_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user935_org1_test
+owneruid: user935_org1_test
 gidnumber: 10114
 memberuid: user935_org1_test
 memberuid: user106_org1_test
@@ -12988,6 +13211,7 @@ objectclass: top
 
 dn: cn=pi_user936_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user936_org1_test
+owneruid: user936_org1_test
 gidnumber: 10061
 memberuid: user936_org1_test
 memberuid: user831_org1_test
@@ -12997,6 +13221,7 @@ objectclass: top
 
 dn: cn=pi_user937_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user937_org1_test
+owneruid: user937_org1_test
 gidnumber: 10171
 memberuid: user937_org1_test
 memberuid: user1195_org1_test
@@ -13007,6 +13232,7 @@ objectclass: top
 
 dn: cn=pi_user938_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user938_org1_test
+owneruid: user938_org1_test
 gidnumber: 10068
 memberuid: user938_org1_test
 memberuid: user907_org1_test
@@ -13017,6 +13243,7 @@ objectclass: top
 
 dn: cn=pi_user940_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user940_org3_test
+owneruid: user940_org3_test
 gidnumber: 10183
 memberuid: user940_org3_test
 memberuid: user299_org3_test
@@ -13027,6 +13254,7 @@ objectclass: top
 
 dn: cn=pi_user955_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user955_org2_test
+owneruid: user955_org2_test
 gidnumber: 10105
 memberuid: user955_org2_test
 memberuid: user802_org2_test
@@ -13038,6 +13266,7 @@ objectclass: top
 
 dn: cn=pi_user957_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user957_org1_test
+owneruid: user957_org1_test
 gidnumber: 10247
 memberuid: user957_org1_test
 memberuid: user31_org1_test
@@ -13050,6 +13279,7 @@ objectclass: top
 
 dn: cn=pi_user962_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user962_org1_test
+owneruid: user962_org1_test
 gidnumber: 10204
 memberuid: user962_org1_test
 memberuid: user696_org1_test
@@ -13061,6 +13291,7 @@ objectclass: top
 
 dn: cn=pi_user967_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user967_org1_test
+owneruid: user967_org1_test
 gidnumber: 10096
 memberuid: user967_org1_test
 memberuid: user683_org1_test
@@ -13073,6 +13304,7 @@ objectclass: top
 
 dn: cn=pi_user968_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user968_org2_test
+owneruid: user968_org2_test
 gidnumber: 10120
 memberuid: user968_org2_test
 objectclass: unityGroup
@@ -13081,6 +13313,7 @@ objectclass: top
 
 dn: cn=pi_user975_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user975_org1_test
+owneruid: user975_org1_test
 gidnumber: 10176
 memberuid: user975_org1_test
 memberuid: user65_org1_test
@@ -13094,6 +13327,7 @@ objectclass: top
 
 dn: cn=pi_user979_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user979_org2_test
+owneruid: user979_org2_test
 gidnumber: 10232
 memberuid: user979_org2_test
 memberuid: user170_org2_test
@@ -13107,6 +13341,7 @@ objectclass: top
 
 dn: cn=pi_user1005_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1005_org3_test
+owneruid: user1005_org3_test
 gidnumber: 10262
 memberuid: user1005_org3_test
 memberuid: user203_org3_test
@@ -13116,6 +13351,7 @@ objectclass: top
 
 dn: cn=pi_user1009_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1009_org1_test
+owneruid: user1009_org1_test
 gidnumber: 10034
 memberuid: user1009_org1_test
 memberuid: user474_org1_test
@@ -13125,6 +13361,7 @@ objectclass: top
 
 dn: cn=pi_user1018_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1018_org2_test
+owneruid: user1018_org2_test
 gidnumber: 10255
 memberuid: user1018_org2_test
 objectclass: unityGroup
@@ -13133,6 +13370,7 @@ objectclass: top
 
 dn: cn=pi_user1019_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1019_org3_test
+owneruid: user1019_org3_test
 gidnumber: 10149
 memberuid: user1019_org3_test
 memberuid: user1138_org3_test
@@ -13144,6 +13382,7 @@ objectclass: top
 
 dn: cn=pi_user1022_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1022_org3_test
+owneruid: user1022_org3_test
 gidnumber: 10163
 memberuid: user1022_org3_test
 memberuid: user159_org3_test
@@ -13153,6 +13392,7 @@ objectclass: top
 
 dn: cn=pi_user1028_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1028_org1_test
+owneruid: user1028_org1_test
 gidnumber: 10134
 memberuid: user1028_org1_test
 memberuid: user21_org1_test
@@ -13165,6 +13405,7 @@ objectclass: top
 
 dn: cn=pi_user1029_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1029_org1_test
+owneruid: user1029_org1_test
 gidnumber: 10148
 memberuid: user1029_org1_test
 memberuid: user903_org1_test
@@ -13174,6 +13415,7 @@ objectclass: top
 
 dn: cn=pi_user1033_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1033_org1_test
+owneruid: user1033_org1_test
 gidnumber: 10196
 memberuid: user1033_org1_test
 memberuid: user1061_org1_test
@@ -13186,6 +13428,7 @@ objectclass: top
 
 dn: cn=pi_user1039_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1039_org1_test
+owneruid: user1039_org1_test
 gidnumber: 10256
 memberuid: user1039_org1_test
 objectclass: unityGroup
@@ -13194,6 +13437,7 @@ objectclass: top
 
 dn: cn=pi_user1045_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1045_org1_test
+owneruid: user1045_org1_test
 gidnumber: 10030
 memberuid: user1045_org1_test
 memberuid: user740_org1_test
@@ -13204,6 +13448,7 @@ objectclass: top
 
 dn: cn=pi_user1053_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1053_org1_test
+owneruid: user1053_org1_test
 gidnumber: 10258
 memberuid: user1053_org1_test
 objectclass: unityGroup
@@ -13212,6 +13457,7 @@ objectclass: top
 
 dn: cn=pi_user1056_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1056_org2_test
+owneruid: user1056_org2_test
 gidnumber: 10270
 memberuid: user1056_org2_test
 objectclass: unityGroup
@@ -13220,6 +13466,7 @@ objectclass: top
 
 dn: cn=pi_user1062_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1062_org1_test
+owneruid: user1062_org1_test
 gidnumber: 10097
 memberuid: user1062_org1_test
 memberuid: user435_org1_test
@@ -13236,6 +13483,7 @@ objectclass: top
 
 dn: cn=pi_user1076_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1076_org1_test
+owneruid: user1076_org1_test
 gidnumber: 10276
 memberuid: user1076_org1_test
 memberuid: user227_org8_test
@@ -13247,6 +13495,7 @@ objectclass: top
 
 dn: cn=pi_user1077_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1077_org2_test
+owneruid: user1077_org2_test
 gidnumber: 10131
 memberuid: user1077_org2_test
 memberuid: user709_org2_test
@@ -13259,6 +13508,7 @@ objectclass: top
 
 dn: cn=pi_user1079_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1079_org1_test
+owneruid: user1079_org1_test
 gidnumber: 10159
 memberuid: user1079_org1_test
 objectclass: unityGroup
@@ -13267,6 +13517,7 @@ objectclass: top
 
 dn: cn=pi_user1082_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1082_org1_test
+owneruid: user1082_org1_test
 gidnumber: 10056
 memberuid: user1082_org1_test
 objectclass: unityGroup
@@ -13275,6 +13526,7 @@ objectclass: top
 
 dn: cn=pi_user1101_org14_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1101_org14_test
+owneruid: user1101_org14_test
 gidnumber: 10269
 memberuid: user1101_org14_test
 objectclass: unityGroup
@@ -13283,6 +13535,7 @@ objectclass: top
 
 dn: cn=pi_user1103_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1103_org2_test
+owneruid: user1103_org2_test
 gidnumber: 10240
 memberuid: user1103_org2_test
 objectclass: unityGroup
@@ -13291,6 +13544,7 @@ objectclass: top
 
 dn: cn=pi_user1109_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1109_org2_test
+owneruid: user1109_org2_test
 gidnumber: 10192
 memberuid: user1109_org2_test
 memberuid: user520_org2_test
@@ -13300,6 +13554,7 @@ objectclass: top
 
 dn: cn=pi_user1110_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1110_org2_test
+owneruid: user1110_org2_test
 gidnumber: 10257
 memberuid: user1110_org2_test
 memberuid: user183_org2_test
@@ -13309,6 +13564,7 @@ objectclass: top
 
 dn: cn=pi_user1111_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1111_org1_test
+owneruid: user1111_org1_test
 gidnumber: 10138
 memberuid: user1111_org1_test
 memberuid: user184_org1_test
@@ -13322,6 +13578,7 @@ objectclass: top
 
 dn: cn=pi_user1118_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1118_org1_test
+owneruid: user1118_org1_test
 gidnumber: 10033
 memberuid: user1118_org1_test
 objectclass: unityGroup
@@ -13330,6 +13587,7 @@ objectclass: top
 
 dn: cn=pi_user1123_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1123_org1_test
+owneruid: user1123_org1_test
 gidnumber: 10140
 memberuid: user1123_org1_test
 memberuid: user169_org1_test
@@ -13345,6 +13603,7 @@ objectclass: top
 
 dn: cn=pi_user11_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user11_org1_test
+owneruid: user11_org1_test
 gidnumber: 10031
 memberuid: user11_org1_test
 memberuid: user156_org6_test
@@ -13359,6 +13618,7 @@ objectclass: top
 
 dn: cn=pi_user1128_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1128_org1_test
+owneruid: user1128_org1_test
 gidnumber: 10284
 memberuid: user1128_org1_test
 objectclass: unityGroup
@@ -13367,6 +13627,7 @@ objectclass: top
 
 dn: cn=pi_user1129_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1129_org1_test
+owneruid: user1129_org1_test
 gidnumber: 10189
 memberuid: user1129_org1_test
 memberuid: user861_org1_test
@@ -13376,6 +13637,7 @@ objectclass: top
 
 dn: cn=pi_user1130_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1130_org1_test
+owneruid: user1130_org1_test
 gidnumber: 10117
 memberuid: user1130_org1_test
 objectclass: unityGroup
@@ -13384,6 +13646,7 @@ objectclass: top
 
 dn: cn=pi_user1140_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1140_org1_test
+owneruid: user1140_org1_test
 gidnumber: 10078
 memberuid: user1140_org1_test
 memberuid: user1193_org5_test
@@ -13396,6 +13659,7 @@ objectclass: top
 
 dn: cn=pi_user1165_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1165_org1_test
+owneruid: user1165_org1_test
 gidnumber: 10055
 memberuid: user1165_org1_test
 memberuid: user1074_org1_test
@@ -13406,6 +13670,7 @@ objectclass: top
 
 dn: cn=pi_user1171_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1171_org1_test
+owneruid: user1171_org1_test
 gidnumber: 10250
 memberuid: user1171_org1_test
 objectclass: unityGroup
@@ -13414,6 +13679,7 @@ objectclass: top
 
 dn: cn=pi_user1175_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1175_org1_test
+owneruid: user1175_org1_test
 gidnumber: 10046
 memberuid: user1175_org1_test
 memberuid: user127_org1_test
@@ -13426,6 +13692,7 @@ objectclass: top
 
 dn: cn=pi_user1176_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1176_org1_test
+owneruid: user1176_org1_test
 gidnumber: 10188
 memberuid: user1176_org1_test
 memberuid: user845_org1_test
@@ -13436,6 +13703,7 @@ objectclass: top
 
 dn: cn=pi_user1182_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1182_org2_test
+owneruid: user1182_org2_test
 gidnumber: 10128
 memberuid: user1182_org2_test
 memberuid: user1189_org2_test
@@ -13445,6 +13713,7 @@ objectclass: top
 
 dn: cn=pi_user1185_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1185_org1_test
+owneruid: user1185_org1_test
 gidnumber: 10213
 memberuid: user1185_org1_test
 objectclass: unityGroup
@@ -13453,6 +13722,7 @@ objectclass: top
 
 dn: cn=pi_user1187_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1187_org1_test
+owneruid: user1187_org1_test
 gidnumber: 10208
 memberuid: user1187_org1_test
 objectclass: unityGroup
@@ -13461,6 +13731,7 @@ objectclass: top
 
 dn: cn=pi_user1191_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1191_org2_test
+owneruid: user1191_org2_test
 gidnumber: 10231
 memberuid: user1191_org2_test
 memberuid: user594_org2_test
@@ -13470,6 +13741,7 @@ objectclass: top
 
 dn: cn=pi_user1201_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1201_org1_test
+owneruid: user1201_org1_test
 gidnumber: 10249
 memberuid: user1201_org1_test
 objectclass: unityGroup
@@ -13478,6 +13750,7 @@ objectclass: top
 
 dn: cn=pi_user1227_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1227_org1_test
+owneruid: user1227_org1_test
 gidnumber: 10244
 memberuid: user1227_org1_test
 memberuid: user260_org1_test
@@ -13487,6 +13760,7 @@ objectclass: top
 
 dn: cn=pi_user1233_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1233_org1_test
+owneruid: user1233_org1_test
 gidnumber: 10273
 memberuid: user1233_org1_test
 memberuid: user465_org1_test
@@ -13496,6 +13770,7 @@ objectclass: top
 
 dn: cn=pi_user1234_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1234_org1_test
+owneruid: user1234_org1_test
 gidnumber: 10282
 memberuid: user1234_org1_test
 objectclass: unityGroup
@@ -13504,6 +13779,7 @@ objectclass: top
 
 dn: cn=pi_user1235_org3_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1235_org3_test
+owneruid: user1235_org3_test
 gidnumber: 10041
 memberuid: user1235_org3_test
 memberuid: user961_org3_test
@@ -13514,6 +13790,7 @@ objectclass: top
 
 dn: cn=pi_user1246_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1246_org2_test
+owneruid: user1246_org2_test
 gidnumber: 10049
 memberuid: user1246_org2_test
 memberuid: user298_org2_test
@@ -13532,6 +13809,7 @@ objectclass: top
 
 dn: cn=pi_user1255_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1255_org1_test
+owneruid: user1255_org1_test
 gidnumber: 10146
 memberuid: user1255_org1_test
 objectclass: unityGroup
@@ -13540,6 +13818,7 @@ objectclass: top
 
 dn: cn=pi_user1260_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1260_org2_test
+owneruid: user1260_org2_test
 gidnumber: 10043
 memberuid: user1260_org2_test
 memberuid: user1215_org2_test
@@ -13549,6 +13828,7 @@ objectclass: top
 
 dn: cn=pi_user1280_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1280_org1_test
+owneruid: user1280_org1_test
 gidnumber: 10109
 memberuid: user1280_org1_test
 memberuid: user1183_org1_test
@@ -13560,6 +13840,7 @@ objectclass: top
 
 dn: cn=pi_user1292_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1292_org1_test
+owneruid: user1292_org1_test
 gidnumber: 10032
 memberuid: user1292_org1_test
 memberuid: user428_org1_test
@@ -13586,6 +13867,7 @@ objectclass: top
 
 dn: cn=pi_user1293_org2_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1293_org2_test
+owneruid: user1293_org2_test
 gidnumber: 10265
 memberuid: user1293_org2_test
 memberuid: user537_org2_test
@@ -13595,6 +13877,7 @@ objectclass: top
 
 dn: cn=pi_user1298_org1_test,ou=pi_groups,dc=unityhpc,dc=test
 cn: pi_user1298_org1_test
+owneruid: user1298_org1_test
 gidnumber: 10210
 memberuid: user1298_org1_test
 objectclass: unityGroup
@@ -37333,6 +37616,7 @@ objectClass: posixGroup
 objectClass: top
 gidNumber: 20007
 cn: pi_cs123_org1_test
+owneruid: cs123_org1_test
 manageruid: user1_org1_test
 memberuid: cs123_org1_test
 memberuid: user1_org1_test

--- a/webroot/admin/pi-mgmt.php
+++ b/webroot/admin/pi-mgmt.php
@@ -24,10 +24,10 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         case "req":
             $form_user = $getUserFromPost();
             if ($_POST["action"] == "Approve") {
-                $group = $form_user->getPIGroup();
+                $group = $form_user->getNamesakePIGroup();
                 $group->approveGroup();
             } elseif ($_POST["action"] == "Deny") {
-                $group = $form_user->getPIGroup();
+                $group = $form_user->getNamesakePIGroup();
                 $group->denyGroup();
             }
             break;
@@ -132,7 +132,7 @@ $CSRFTokenHiddenFormInput = UnityHTTPD::getCSRFTokenHiddenFormInput();
     usort($owner_attributes, fn($a, $b) => strcmp($a["uid"][0], $b["uid"][0]));
     foreach ($owner_attributes as $attributes) {
         $gecos = $attributes["gecos"][0];
-        $gid = UnityGroup::OwnerUID2GID($attributes["uid"][0]);
+        $gid = UnityGroup::ownerUID2NamesakeGID($attributes["uid"][0]);
         $mail = $attributes["mail"][0];
         echo "
             <tr>

--- a/webroot/admin/pi-mgmt.php
+++ b/webroot/admin/pi-mgmt.php
@@ -18,22 +18,26 @@ $getUserFromPost = function () {
     return new UnityUser(UnityHTTPD::getPostData("uid"), $LDAP, $SQL, $MAILER);
 };
 
+$getGroupFromPost = function () {
+    global $LDAP, $SQL, $MAILER;
+    return new UnityGroup(UnityHTTPD::getPostData("pi"), $LDAP, $SQL, $MAILER);
+};
+
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
     UnityHTTPD::validatePostCSRFToken();
     switch ($_POST["form_type"]) {
         case "req":
-            $form_user = $getUserFromPost();
+            $owner = $getUserFromPost();
+            $group = $getGroupFromPost();
             if ($_POST["action"] == "Approve") {
-                $group = $form_user->getNamesakePIGroup();
-                $group->approveGroup();
+                $group->approveGroup($owner->uid);
             } elseif ($_POST["action"] == "Deny") {
-                $group = $form_user->getNamesakePIGroup();
-                $group->denyGroup();
+                $group->denyGroup($owner->uid);
             }
             break;
         case "reqChild":
             $form_user = $getUserFromPost();
-            $parent_group = new UnityGroup($_POST["pi"], $LDAP, $SQL, $MAILER);
+            $parent_group = $getGroupFromPost();
             if ($_POST["action"] == "Approve") {
                 $parent_group->approveUser($form_user);
             } elseif ($_POST["action"] == "Deny") {
@@ -42,11 +46,11 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             break;
         case "remUserChild":
             $form_user = $getUserFromPost();
-            $parent = new UnityGroup($_POST["pi"], $LDAP, $SQL, $MAILER);
+            $parent = $getGroupFromPost();
             $parent->removeUser($form_user, UnityGroupUserRemovedReason::RemovedByAdmin);
             break;
         case "disable":
-            $group = new UnityGroup(UnityHTTPD::getPostData("pi"), $LDAP, $SQL, $MAILER);
+            $group = $getGroupFromPost();
             if ($group->getIsDisabled()) {
                 UnityHTTPD::messageError("Cannot Disable PI Group", "Group is already disabled");
                 UnityHTTPD::redirect();
@@ -79,7 +83,7 @@ $CSRFTokenHiddenFormInput = UnityHTTPD::getCSRFTokenHiddenFormInput();
     </thead>
     <tbody>
     <?php
-    $requests = $SQL->getRequests(UnitySQL::REQUEST_BECOME_PI);
+    $requests = $SQL->getRequests(UnitySQL::REQUEST_CREATE_PI_GROUP);
 
     foreach ($requests as $request) {
         $uid = $request["uid"];

--- a/webroot/panel/account.php
+++ b/webroot/panel/account.php
@@ -112,7 +112,7 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
             if ($_POST["tos"] != "agree") {
                 UnityHTTPD::badRequest("user did not agree to terms of service");
             }
-            $USER->getPIGroup()->requestGroup();
+            $USER->getNamesakePIGroup()->requestGroup();
             UnityHTTPD::messageSuccess("PI Group Requested", "");
             UnityHTTPD::redirect();
             break; /** @phpstan-ignore deadCode.unreachable */
@@ -121,7 +121,7 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
                 UnityHTTPD::messageError("Cannot Cancel PI Request", "No PI request found");
                 UnityHTTPD::redirect();
             }
-            $USER->getPIGroup()->cancelGroupRequest();
+            $USER->getNamesakePIGroup()->cancelGroupRequest();
             UnityHTTPD::messageSuccess("PI Request Cancelled", "");
             UnityHTTPD::redirect();
             break; /** @phpstan-ignore deadCode.unreachable */
@@ -178,7 +178,7 @@ if ($isPI) {
         <p>You are currently a <strong>principal investigator</strong> on the Unity HPC Platform.</p>
     ";
 } else {
-    if ($USER->getPIGroup()->exists() && $USER->getPIGroup()->getIsDisabled()) {
+    if ($USER->getNamesakePIGroup()->exists() && $USER->getNamesakePIGroup()->getIsDisabled()) {
         echo "<p>You are no longer a PI because your PI group is disabled.</p>";
     }
     if ($USER->getFlag(UserFlag::QUALIFIED)) {
@@ -227,7 +227,7 @@ if (!$isPI) {
             <input type='hidden' name='form_type' value='cancel_pi_request'/>
         ";
     } else {
-        if ($USER->getPIGroup()->exists() && $USER->getPIGroup()->getIsDisabled()) {
+        if ($USER->getNamesakePIGroup()->exists() && $USER->getNamesakePIGroup()->getIsDisabled()) {
             $button_msg = "Request to Re-Enable PI Group";
             $onclick = "return confirm(\"Are you sure you want to re-enable your old PI group?\")";
         } else {

--- a/webroot/panel/account.php
+++ b/webroot/panel/account.php
@@ -105,23 +105,27 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
                 UnityHTTPD::messageError("Cannot Submit PI Request", "Already a PI");
                 UnityHTTPD::redirect();
             }
-            if ($SQL->requestExists($USER->uid, UnitySQL::REQUEST_BECOME_PI)) {
+            $group = $USER->getNamesakePIGroup();
+            $request = "$USER->uid:$group->gid";
+            if ($SQL->requestExists($request, UnitySQL::REQUEST_CREATE_PI_GROUP)) {
                 UnityHTTPD::messageError("Cannot Submit PI Request", "This request already exists");
                 UnityHTTPD::redirect();
             }
             if ($_POST["tos"] != "agree") {
                 UnityHTTPD::badRequest("user did not agree to terms of service");
             }
-            $USER->getNamesakePIGroup()->requestGroup();
+            $group->requestGroup($USER->uid);
             UnityHTTPD::messageSuccess("PI Group Requested", "");
             UnityHTTPD::redirect();
             break; /** @phpstan-ignore deadCode.unreachable */
         case "cancel_pi_request":
-            if (!$SQL->requestExists($USER->uid, UnitySQL::REQUEST_BECOME_PI)) {
+            $group = $USER->getNamesakePIGroup();
+            $request = "$USER->uid:$group->gid";
+            if (!$SQL->requestExists($request, UnitySQL::REQUEST_CREATE_PI_GROUP)) {
                 UnityHTTPD::messageError("Cannot Cancel PI Request", "No PI request found");
                 UnityHTTPD::redirect();
             }
-            $USER->getNamesakePIGroup()->cancelGroupRequest();
+            $group->cancelGroupRequest($USER->uid);
             UnityHTTPD::messageSuccess("PI Request Cancelled", "");
             UnityHTTPD::redirect();
             break; /** @phpstan-ignore deadCode.unreachable */
@@ -217,7 +221,7 @@ if (!$isPI) {
         >
     ";
     echo $CSRFTokenHiddenFormInput;
-    if ($SQL->requestExists($USER->uid, UnitySQL::REQUEST_BECOME_PI)) {
+    if ($SQL->requestExists($USER->uid, UnitySQL::REQUEST_CREATE_PI_GROUP)) {
         $onclick = "return confirm(\"Are you sure you want to cancel this request?\")";
         echo "<input type='submit' value='Cancel PI Account Request' onclick='$onclick'/>";
         echo "

--- a/webroot/panel/modal/new_pi.php
+++ b/webroot/panel/modal/new_pi.php
@@ -15,7 +15,7 @@ $owner_attributes = $LDAP->getUsersAttributes(
 );
 $pi_group_gid_to_owner_gecos_and_mail = [];
 foreach ($owner_attributes as $attributes) {
-    $gid = UnityGroup::ownerUID2GID($attributes["uid"][0]);
+    $gid = UnityGroup::ownerUID2NamesakeGID($attributes["uid"][0]);
     $pi_group_gid_to_owner_gecos_and_mail[$gid] = [$attributes["gecos"][0], $attributes["mail"][0]];
 }
 $_SESSION["pi_group_gid_to_owner_gecos_and_mail"] = $pi_group_gid_to_owner_gecos_and_mail;

--- a/webroot/panel/pi.php
+++ b/webroot/panel/pi.php
@@ -17,7 +17,7 @@ if (($gid = $_GET["gid"] ?? null) !== null) {
         UnityHTTPD::forbidden("not a manager of group '$gid'", "You cannot manage this group.");
     }
 } else {
-    $group = $USER->getPIGroup();
+    $group = $USER->getNamesakePIGroup();
     $user_is_owner = true;
     if (!$group->exists()) {
         UnityHTTPD::badRequest("not a PI", "You are not a PI.");

--- a/workers/setup-pi-group-owners.php
+++ b/workers/setup-pi-group-owners.php
@@ -1,0 +1,12 @@
+#!/usr/bin/env php
+<?php
+include __DIR__ . "/init.php";
+
+use UnityWebPortal\lib\UnityGroup;
+use UnityWebPortal\lib\UnityLDAP;
+
+foreach ($LDAP->getPIGroupsAttributes(["cn"], filter: UnityLDAP::INCLUDE_DISABLED) as $attributes) {
+    $gid = $attributes["cn"][0];
+    $entry->setAttribute("ownerUid", UnityGroup::GID2OwnerUID($gid));
+}
+

--- a/workers/setup-pi-group-owners.php
+++ b/workers/setup-pi-group-owners.php
@@ -8,6 +8,6 @@ use UnityWebPortal\lib\UnityLDAP;
 foreach ($LDAP->getPIGroupsAttributes(["cn"], filter: UnityLDAP::INCLUDE_DISABLED) as $attributes) {
     $gid = $attributes["cn"][0];
     $entry = $LDAP->getPIGroupEntry($gid);
-    $entry->setAttribute("ownerUid", UnityGroup::GID2OwnerUID($gid));
+    $entry->setAttribute("ownerUid", UnityGroup::NamesakeGID2OwnerUID($gid));
 }
 

--- a/workers/setup-pi-group-owners.php
+++ b/workers/setup-pi-group-owners.php
@@ -7,6 +7,7 @@ use UnityWebPortal\lib\UnityLDAP;
 
 foreach ($LDAP->getPIGroupsAttributes(["cn"], filter: UnityLDAP::INCLUDE_DISABLED) as $attributes) {
     $gid = $attributes["cn"][0];
+    $entry = $LDAP->getPIGroupEntry($gid);
     $entry->setAttribute("ownerUid", UnityGroup::GID2OwnerUID($gid));
 }
 

--- a/workers/unity-course.php
+++ b/workers/unity-course.php
@@ -15,10 +15,20 @@ $owner_uid = trim(
         "Enter the UID of the Unity admin responsible for the group (example: simonleary_umass_edu): ",
     ),
 );
+$manager_uid = trim(
+    readline(
+        "Enter the UID of the faculty member responsible for the group (example: simonleary_umass_edu): ",
+    ),
+);
 
 $owner = new UnityUser($owner_uid, $LDAP, $SQL, $MAILER);
 if (!$owner->exists()) {
     _die("no such user: '$owner_uid'", 1);
+}
+
+$manager = new UnityUser($manager_uid, $LDAP, $SQL, $MAILER);
+if (!$manager->exists()) {
+    _die("no such user: '$manager_uid'", 1);
 }
 
 $course_pi_group = new UnityGroup($gid, $LDAP, $SQL, $MAILER);
@@ -27,8 +37,11 @@ if ($course_pi_group->exists()) {
     _die("course PI group already exists: '$course_pi_group_dn'", 1);
 }
 
-$course_pi_group->requestGroup($owner_uid, false, false);
-$course_pi_group->approveGroup($owner_uid);
+$course_pi_group->requestGroup($owner_uid, send_mail: false, send_mail_to_admins: false);
+$course_pi_group->approveGroup($owner_uid, send_mail: true);
+$course_pi_group->newUserRequest($manager, send_mail: false);
+$course_pi_group->approveUser($manager, send_mail: true);
+$course_pi_group->addManagerUID($manager_uid);
 
 $entry = $LDAP->getPIGroupEntry($course_pi_group->gid);
 $entry->setAttribute("description", "$course_id $course_notes");

--- a/workers/unity-course.php
+++ b/workers/unity-course.php
@@ -3,74 +3,36 @@
 $_SERVER["HTTP_HOST"] = "course-creator"; // see deployment/overrides/course-creator
 include __DIR__ . "/init.php";
 use UnityWebPortal\lib\UnityUser;
-use UnityWebPortal\lib\UnityOrg;
-use UnityWebPortal\lib\UserFlag;
+use UnityWebPortal\lib\UnityGroup;
 
-function cn2org($cn)
-{
-    $matches = [];
-    _preg_match("/.*_([^_]+_[^_]+)$/", $cn, $matches);
-    assert(count($matches) == 2, "failed to extract org from cn: '$cn'");
-    return $matches[1];
-}
-
-// if array is length 1 then replace it with its one element
-function flatten_attributes(array $attributes): array
-{
-    return array_map(fn($v) => count($v) === 1 ? $v[0] : $v, $attributes);
-}
-
-$givenName = trim(readline("Enter the course ID (example: CS123): "));
-$sn = trim(readline("Enter the year and semester of the course (example: Fall 2025): "));
-$cn = strtolower(
+$course_id = trim(readline("Enter the course ID (example: CS123): "));
+$course_notes = trim(readline("Enter the year and semester of the course (example: Fall 2025): "));
+$gid = strtolower(
     trim(readline("Please enter the cn to be used for the course (example: cs123_umass_edu): ")),
 );
-$manager_uid = trim(
-    readline("Enter the UID of the group manager (example: simonleary_umass_edu): "),
+$owner_uid = trim(
+    readline(
+        "Enter the UID of the Unity admin responsible for the group (example: simonleary_umass_edu): ",
+    ),
 );
-$org_gid = cn2org($cn);
 
-$manager = new UnityUser($manager_uid, $LDAP, $SQL, $MAILER);
-if (!$manager->exists()) {
-    _die("no such user: '$manager_uid'", 1);
+$owner = new UnityUser($owner_uid, $LDAP, $SQL, $MAILER);
+if (!$owner->exists()) {
+    _die("no such user: '$owner_uid'", 1);
 }
 
-$course_user = new UnityUser($cn, $LDAP, $SQL, $MAILER);
-if ($course_user->exists()) {
-    $course_user_dn = $LDAP->getUserEntry($cn)->getDN();
-    _die("course user already exists: '$course_user_dn'", 1);
-}
-$org = new UnityOrg($org_gid, $LDAP);
-if (!$org->exists()) {
-    print "WARNING: creating new org '$org_gid'...\n";
-}
-$mail = ""; // temporary empty mail
-$course_user->init($givenName, $sn, $mail, $org_gid);
-$course_user->setFlag(UserFlag::IMMORTAL, true, false, true);
-
-$course_pi_group = $course_user->getNamesakePIGroup();
-$course_user->setMail($course_pi_group->addPlusAddressToMail($manager->getMail()));
-
+$course_pi_group = new UnityGroup($gid, $LDAP, $SQL, $MAILER);
 if ($course_pi_group->exists()) {
     $course_pi_group_dn = $LDAP->getPIGroupEntry($course_pi_group->gid)->getDN();
     _die("course PI group already exists: '$course_pi_group_dn'", 1);
 }
-$course_pi_group->requestGroup(false, false);
-$course_pi_group->approveGroup();
 
-$course_pi_group->newUserRequest($manager, false);
-$course_pi_group->approveUser($manager);
-$course_pi_group->addManagerUID($manager_uid);
+$course_pi_group->requestGroup($owner_uid, false, false);
+$course_pi_group->approveGroup($owner_uid);
 
-print "LDAP entries created:\n";
-print _json_encode(
-    [
-        "course user" => flatten_attributes($LDAP->getUserEntry($cn)->getAttributes()),
-        "course user group" => flatten_attributes($LDAP->getUserGroupEntry($cn)->getAttributes()),
-        "course PI group" => flatten_attributes(
-            $LDAP->getPIGroupEntry($course_pi_group->gid)->getAttributes(),
-        ),
-    ],
-    JSON_PRETTY_PRINT,
-);
+$entry = $LDAP->getPIGroupEntry($course_pi_group->gid);
+$entry->setAttribute("description", "$course_id $course_notes");
+
+print "PI group created:\n";
+print _json_encode($entry->getAttributes(), JSON_PRETTY_PRINT);
 

--- a/workers/unity-course.php
+++ b/workers/unity-course.php
@@ -48,7 +48,7 @@ $mail = ""; // temporary empty mail
 $course_user->init($givenName, $sn, $mail, $org_gid);
 $course_user->setFlag(UserFlag::IMMORTAL, true, false, true);
 
-$course_pi_group = $course_user->getPIGroup();
+$course_pi_group = $course_user->getNamesakePIGroup();
 $course_user->setMail($course_pi_group->addPlusAddressToMail($manager->getMail()));
 
 if ($course_pi_group->exists()) {

--- a/workers/user-expiry.php
+++ b/workers/user-expiry.php
@@ -76,7 +76,7 @@ function sendUserExpiryNoticeToPIGroupOwners(string $template, UnityUser $user)
     global $LDAP, $SQL, $MAILER;
     foreach ($LDAP->getPIGroupGIDsWithMemberUID($user->uid) as $gid) {
         $group = new UnityGroup($gid, $LDAP, $SQL, $MAILER);
-        sendMail($group->getOwnerMailAndManagerMails(), $template, [
+        sendMail($group->getOwnerMailAndPlusAddressedManagerMails(), $template, [
             "group" => $gid,
             "user" => $user->uid,
             "org" => $user->getOrg(),

--- a/workers/user-expiry.php
+++ b/workers/user-expiry.php
@@ -46,7 +46,7 @@ $pi_group_members = [];
 foreach ($LDAP->getPIGroupsAttributes(["cn", "memberuid"], ["memberuid" => []]) as $attributes) {
     $pi_group_members[$attributes["cn"][0]] = $attributes["memberuid"];
 }
-$pi_group_owners = array_map(UnityGroup::GID2OwnerUID(...), array_keys($pi_group_members));
+$pi_group_owners = array_map(UnityGroup::NamesakeGID2OwnerUID(...), array_keys($pi_group_members));
 
 $initially_idlelocked_users = $LDAP->userFlagGroups["idlelocked"]->getMemberUIDs();
 $initially_disabled_users = $LDAP->userFlagGroups["disabled"]->getMemberUIDs();
@@ -135,7 +135,7 @@ function disableWarnUser(UnityUser $user, int $day)
     $idle_days = $uid_to_idle_days[$user->uid];
     $expiration_date = date("Y/m/d", $last_login + $disable_day * 24 * 60 * 60);
     $is_final_warning = $day === $final_disable_warning_day;
-    $pi_group_gid = UnityGroup::ownerUID2GID($user->uid);
+    $pi_group_gid = UnityGroup::ownerUID2NamesakeGID($user->uid);
     $pi_group_member_uids = $pi_group_members[$pi_group_gid] ?? [];
     $mail_template_data = [
         "user" => $user->uid,

--- a/workers/user-expiry.php
+++ b/workers/user-expiry.php
@@ -76,7 +76,7 @@ function sendUserExpiryNoticeToPIGroupOwners(string $template, UnityUser $user)
     global $LDAP, $SQL, $MAILER;
     foreach ($LDAP->getPIGroupGIDsWithMemberUID($user->uid) as $gid) {
         $group = new UnityGroup($gid, $LDAP, $SQL, $MAILER);
-        sendMail($group->getOwnerMailAndPlusAddressedManagerMails(), $template, [
+        sendMail($group->getOwnerMailAndManagerMails(), $template, [
             "group" => $gid,
             "user" => $user->uid,
             "org" => $user->getOrg(),


### PR DESCRIPTION
Allows one user to be the owner of multiple PI groups. This is an experiment. It provides relatively little benefit and a relatively large amount of breaking changes.

* this is branched from https://github.com/UnityHPC/account-portal/pull/736, should be rebased later
* PI group requests in SQL must now contain the GID as well as the owner UID
    * the `uid` column in the `requests` SQL table is no longer well-named
    * the request-type constant `REQUEST_BECOME_PI` is now `REQUEST_CREATE_PI_GROUP`
* PI-group-request-related functions in `UnityGroup` now require the owner UID as an argument
* the old 1:1 owner UID <-> PI group GID conversion process is now called "namesake"
    * the constant `PI_PREFIX` is now `NAMESAKE_PI_PREFIX`
    * the function `GID2OwnerUID` is now `NamesakeGID2OwnerUID`
    * the function `OwnerUID2GID` is now `OwnerUID2NamesakeGID`
* removed dummy course group owners
* the `unity-course.php` worker now prompts for an admin username (owner) and a faculty username (manager)
* the Unity admin involved with a course group can no longer benefit from plus addressing