### PR TITLE
make generate key more intuitive

### DIFF
--- a/webroot/panel/account.php
+++ b/webroot/panel/account.php
@@ -75,7 +75,7 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
                 $USER->addSSHKey($key);
                 $sha256_fingerprint = getSSHKeyInfo($key)[1];
                 $stub_fingprint = substr($sha256_fingerprint, 0, 6);
-                UnityHTTPD::messageSuccess("SSH Key Added", $stub_fingprint);
+                UnityHTTPD::messageSuccess("SSH Key Added", "Fingerprint: $stub_fingprint");
             }
             UnityHTTPD::redirect();
             break; /** @phpstan-ignore deadCode.unreachable */

--- a/webroot/panel/modal/new_key.php
+++ b/webroot/panel/modal/new_key.php
@@ -14,25 +14,17 @@ $CSRFTokenHiddenFormInput = UnityHTTPD::getCSRFTokenHiddenFormInput();
     <?php echo $CSRFTokenHiddenFormInput; ?>
     <input type='hidden' name='form_type' value='addKey'>
 
-    <div class='inline'>
-        <input type="radio" id="paste" name="add_type" value="paste" checked>
-        <label for="paste">Paste Key</label>
-    </div>
-
-    <div class='inline'>
-        <input type="radio" id="import" name="add_type" value="import">
-        <label for="import">Local File</label>
-    </div>
-
-    <div class='inline'>
-        <input type="radio" id="generate" name="add_type" value="generate">
-        <label for="generate">Generate Key</label>
-    </div>
-
-    <div class='inline'>
-        <input type="radio" id="github" name="add_type" value="github">
-        <label for="github">Import from GitHub</label>
-    </div>
+    <input type="radio" id="paste" name="add_type" value="paste" checked>
+    <label for="paste">Paste Key</label>
+    <br>
+    <input type="radio" id="import" name="add_type" value="import">
+    <label for="import">Local File</label>
+    <br>
+    <input type="radio" id="generate" name="add_type" value="generate">
+    <label for="generate">Generate Key</label>
+    <br>
+    <input type="radio" id="github" name="add_type" value="github">
+    <label for="github">Import from GitHub</label>
 
     <hr>
 
@@ -51,10 +43,29 @@ $CSRFTokenHiddenFormInput = UnityHTTPD::getCSRFTokenHiddenFormInput();
 
     <div style="display: none;" id="key_generate">
         <input type="hidden" name="gen_key" />
-        <button type="button" class="btnLin">OpenSSH</button>
-        <button type="button" class="btnWin">PuTTY</button>
-        <input type="submit" value="Upload Public Key" disabled />
-        <br>
+        <table style="border-spacing: 5px;">
+            <tr>
+                <td>
+                    <span id="generate_key_download_checkmark">&hellip;</span>
+                </td>
+                <td>Download Private Key</td>
+                <td>
+                    <div style="display: flex; gap: 5px;" id="key_generate_download_buttons">
+                        <button type="button" class="btnLin">OpenSSH (recommended)</button>
+                        <button type="button" class="btnWin">PuTTY</button>
+                    </div>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <span id="generate_key_upload_checkmark">&hellip;</span>
+                </td>
+                <td>Upload Public Key</td>
+                <td>
+                    <input id="key_generate_upload_button" type="submit" value="Upload" disabled />
+                </td>
+            </tr>
+        </table>
         <p style="margin-top: 10px;">
             Once you download your private key, you must also upload your public key.
         </p>
@@ -71,7 +82,7 @@ $CSRFTokenHiddenFormInput = UnityHTTPD::getCSRFTokenHiddenFormInput();
 <script>
     $("input[type=radio]").change(function() {
         if ($(this).is(":checked")) {
-            $("[id^=key_]").hide()  // Hide existing divs
+            $("#newKeyform > div").hide()  // Hide existing divs
             $("div#key_" + $(this).attr('id')).show();  // show only one div
         }
     });
@@ -83,6 +94,7 @@ $CSRFTokenHiddenFormInput = UnityHTTPD::getCSRFTokenHiddenFormInput();
             success: function(result) {
                 $("input[type=hidden][name=gen_key]").val(result.public);
                 downloadFile(result.private, "privkey." + type); // Force download of private key
+                $("#generate_key_download_checkmark").text("✅");
             },
             error: function (result) {
                 $("#key_generate").append(result.responseText);
@@ -90,7 +102,7 @@ $CSRFTokenHiddenFormInput = UnityHTTPD::getCSRFTokenHiddenFormInput();
         });
     }
 
-    $("div#key_generate > button").click(function() {
+    $("#key_generate_download_buttons > button").click(function() {
         // get type
         if ($(this).hasClass('btnWin')) {
             var type = "ppk";
@@ -100,10 +112,8 @@ $CSRFTokenHiddenFormInput = UnityHTTPD::getCSRFTokenHiddenFormInput();
 
         generateKey(type);
         setTimeout(() => {
-            $(this).siblings("input[type=submit]").prop("disabled", false);
-            // for some reason $(this).siblings("button") is missing btnLin
-            // btnLin is in $(this).siblings().prevObject
-            $("#key_generate > button").prop("disabled", true);
+            $("#key_generate_upload_button").prop("disabled", false);
+            $("#key_generate_download_buttons > button").prop("disabled", true);
         }, 300);
     });
 

--- a/webroot/panel/modal/new_key.php
+++ b/webroot/panel/modal/new_key.php
@@ -62,7 +62,7 @@ $CSRFTokenHiddenFormInput = UnityHTTPD::getCSRFTokenHiddenFormInput();
                 </td>
                 <td>Upload Public Key</td>
                 <td>
-                    <input id="key_generate_upload_button" type="submit" value="Upload" disabled />
+                    <button type="button" id="key_generate_upload_button" disabled>Upload</button>
                 </td>
             </tr>
         </table>
@@ -87,7 +87,13 @@ $CSRFTokenHiddenFormInput = UnityHTTPD::getCSRFTokenHiddenFormInput();
         }
     });
 
-    function generateKey(type) {
+    $("#key_generate_download_buttons > button").click(function() {
+        // get type
+        if ($(this).hasClass('btnWin')) {
+            var type = "ppk";
+        } else if ($(this).hasClass('btnLin')) {
+            var type = "key";
+        }
         $.ajax({
             url: "<?php echo getRelativeURL("panel/ajax/ssh_generate.php"); ?>?type=" + type,
             dataType: "json",
@@ -105,21 +111,15 @@ $CSRFTokenHiddenFormInput = UnityHTTPD::getCSRFTokenHiddenFormInput();
                 $("#key_generate").append(result.responseText);
             },
         });
-    }
-
-    $("#key_generate_download_buttons > button").click(function() {
-        // get type
-        if ($(this).hasClass('btnWin')) {
-            var type = "ppk";
-        } else if ($(this).hasClass('btnLin')) {
-            var type = "key";
-        }
-
-        generateKey(type);
         setTimeout(() => {
             $("#key_generate_upload_button").prop("disabled", false);
             $("#key_generate_download_buttons > button").prop("disabled", true);
         }, 300);
+    });
+
+    $("#key_generate_upload_button").click(function() {
+        $("#generate_key_upload_checkmark").text("✅");
+        $("#newKeyform").submit();
     });
 
     $("#key_paste > textarea").on("input", function() {

--- a/webroot/panel/modal/new_key.php
+++ b/webroot/panel/modal/new_key.php
@@ -101,6 +101,8 @@ $CSRFTokenHiddenFormInput = UnityHTTPD::getCSRFTokenHiddenFormInput();
                 $("input[type=hidden][name=gen_key]").val(result.public);
                 downloadFile(result.private, "privkey." + type); // Force download of private key
                 $("#generate_key_download_checkmark").text("✅");
+                $("#key_generate_upload_button").prop("disabled", false);
+                $("#key_generate_download_buttons > button").prop("disabled", true);
                 // now that private key is downloading, don't let them close the modal or
                 // switch method until they upload the pubkey (which reloads the page)
                 $("#modal").attr("closedby", "none");
@@ -111,10 +113,6 @@ $CSRFTokenHiddenFormInput = UnityHTTPD::getCSRFTokenHiddenFormInput();
                 $("#key_generate").append(result.responseText);
             },
         });
-        setTimeout(() => {
-            $("#key_generate_upload_button").prop("disabled", false);
-            $("#key_generate_download_buttons > button").prop("disabled", true);
-        }, 300);
     });
 
     $("#key_generate_upload_button").click(function() {

--- a/webroot/panel/modal/new_key.php
+++ b/webroot/panel/modal/new_key.php
@@ -95,6 +95,11 @@ $CSRFTokenHiddenFormInput = UnityHTTPD::getCSRFTokenHiddenFormInput();
                 $("input[type=hidden][name=gen_key]").val(result.public);
                 downloadFile(result.private, "privkey." + type); // Force download of private key
                 $("#generate_key_download_checkmark").text("✅");
+                // now that private key is downloading, don't let them close the modal or
+                // switch method until they upload the pubkey (which reloads the page)
+                $("#modal").attr("closedby", "none");
+                $("#modalCloseButton").prop("disabled", true);
+                $("#newKeyform > input[type=radio]:not(:checked)").prop("disabled", true);
             },
             error: function (result) {
                 $("#key_generate").append(result.responseText);


### PR DESCRIPTION
In https://github.com/UnityHPC/account-portal/pull/622 I broke the "generate key" flow into two stages. If a user does the first stage (which from their perspective is identical to the old flow), and then they close out the modal, they have just downloaded a useless key, and will likely become frustrated when they can't login. To prevent this, I separate the two stages onto two lines, show a checkmark when a stage is complete, and prevent the user from leaving the modal until they upload.

before:

https://github.com/user-attachments/assets/c2a0e7ac-4097-435d-8956-df1aa74ec884

after:

https://github.com/user-attachments/assets/ed722f39-4752-4b63-875e-e1bdaeb08082



