### PR TITLE
include exception location in error log

### DIFF
--- a/resources/lib/UnityHTTPD.php
+++ b/resources/lib/UnityHTTPD.php
@@ -153,6 +153,7 @@ class UnityHTTPD
         $output = [
             "class" => get_class($t),
             "msg" => $t->getMessage(),
+            "location" => sprintf("%s:%d", $t->getFile(), $t->getLine()),
             // newlines are bad for error log, but getTrace() is too verbose
             "trace" => explode("\n", $t->getTraceAsString()),
         ];


### PR DESCRIPTION
before:
`[Wed Jun 17 18:38:20.682892 2026] [php:notice] [pid 25] [client 172.18.0.1:58194] internal server error: {"message":"","error":{"class":"DivisionByZeroError","msg":"Division by zero","trace":["#0 {main}"]},"REMOTE_USER":"user1@org1.test","REMOTE_ADDR":"172.18.0.1","errorid":"6a32e99ca6b59"}, referer: http://127.0.0.1:8000/panel/account.php`

after:
`[Wed Jun 17 18:37:29.459972 2026] [php:notice] [pid 24] [client 172.18.0.1:60122] internal server error: {"message":"","error":{"class":"DivisionByZeroError","msg":"Division by zero","location":"/var/www/unity-web-portal/webroot/panel/account.php:15","trace":["#0 {main}"]},"REMOTE_USER":"user1@org1.test","REMOTE_ADDR":"172.18.0.1","errorid":"6a32e96970494"}, referer: http://127.0.0.1:8000/panel/account.php`