### PR TITLE
move composer, npm inside the `web` container

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -63,4 +63,4 @@ jobs:
           tools: composer
       - run: composer install --dev
       - run: docker compose -f ./tools/docker-dev/docker-compose.yml up -d --no-build
-      - run: docker compose -f ./tools/docker-dev/docker-compose.yml exec -w '/var/www/unity-web-portal' web bash -c 'XDEBUG_MODE=coverage ./vendor/bin/phpunit --coverage-clover="$(mktemp --suffix=.xml)" -d --min-coverage=./coverage.php'
+      - run: docker compose -f ./tools/docker-dev/docker-compose.yml exec -w '/srv/www/unity-web' web bash -c 'XDEBUG_MODE=coverage ./vendor/bin/phpunit --coverage-clover="$(mktemp --suffix=.xml)" -d --min-coverage=./coverage.php'

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -57,10 +57,5 @@ jobs:
           docker tag ghcr.io/${{ env.REPO_OWNER }}/unity-dev-sql:latest docker-dev-sql
           docker pull ghcr.io/${{ env.REPO_OWNER }}/unity-dev-web:latest
           docker tag ghcr.io/${{ env.REPO_OWNER }}/unity-dev-web:latest docker-dev-web
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: "8.3"
-          tools: composer
-      - run: composer install --dev
       - run: docker compose -f ./tools/docker-dev/docker-compose.yml up -d --no-build
       - run: docker compose -f ./tools/docker-dev/docker-compose.yml exec -w '/srv/www/unity-web' web bash -c 'XDEBUG_MODE=coverage ./vendor/bin/phpunit --coverage-clover="$(mktemp --suffix=.xml)" -d --min-coverage=./coverage.php'

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -42,6 +42,8 @@ jobs:
             --push \
             ./tools/docker-dev/sql
 
+          cp package{-lock,}.json tools/docker-dev/web/
+          cp composer.{json,lock} tools/docker-dev/web/
           docker buildx build \
             --tag ghcr.io/${{ env.REPO_OWNER }}/unity-dev-web:latest \
             --cache-from type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/unity-dev-web:buildcache \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ For details on the changes in each release, see [the Releases page](https://gith
 
 ## Version-specific update instructions:
 
-### 1.8 -> 1.9
+### 1.7 -> 1.8
 - schema migration:
   - add the new LDAP schema in conjunction with the old
   - shut down the account portal
@@ -13,8 +13,6 @@ For details on the changes in each release, see [the Releases page](https://gith
   - run the `setup-pi-group-owners.php` worker
   - restart the account portal
 - the `[config]custom_user_mappings_dir` option should be removed from the config file
-
-### 1.7 -> 1.8
 - the [webhook] section of the config file can be removed
 - all mail templates are no longer PHP files, now they are `.html.twig`
 - the `mail_overrides` directory has been renamed to `mail`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For details on the changes in each release, see [the Releases page](https://gith
   - remove the `piGroup` object class from all PI groups
   - run the `setup-pi-group-owners.php` worker
   - restart the account portal
+- the `[config]custom_user_mappings_dir` option should be removed from the config file
 
 ### 1.7 -> 1.8
 - the [webhook] section of the config file can be removed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ cd ./tools/docker-dev
 tab 2:
 
 ```
-docker exec -it "$(docker container ls | grep web | awk '{print $1}')" bash -c 'cd /var/www/unity-web-portal && ./vendor/bin/phpunit /path/to/test --stop-on-defect'
+docker exec -it "$(docker container ls | grep web | awk '{print $1}')" bash -c 'cd /srv/www/unity-web && ./vendor/bin/phpunit /path/to/test --stop-on-defect'
 ```
 
 For `/path/to/tests/`, you usually want `./test/functional/` but you can select a specific file to save time when troubleshooting specific tests.

--- a/deployment/config.base.ini
+++ b/deployment/config.base.ini
@@ -24,7 +24,6 @@ session_cleanup_idle_seconds = 1800 ; how long a session must be idle before mes
 uri = "ldap://identity"  ; URI of remote LDAP server
 user = "cn=admin,dc=unityhpc,dc=test"  ; Admin bind DN LDAP user
 pass = "password"  ; Admin bind password
-custom_user_mappings_dir = "deployment/custom_user_mappings" ; for internal use only
 basedn = "dc=unityhpc,dc=test"  ; Base search DN
 user_ou = "ou=users,dc=unityhpc,dc=test"  ; User organizational unit (may contain more than user group)
 usergroup_ou = "ou=user_groups,dc=unityhpc,dc=test"  ; Group organizational unit

--- a/resources/lib/UnityDeployment.php
+++ b/resources/lib/UnityDeployment.php
@@ -186,7 +186,7 @@ class UnityDeployment
     public static function getCustomIDMappings(): array
     {
         $output = [];
-        $dir_path = __DIR__ . "/../../" . CONFIG["ldap"]["custom_user_mappings_dir"];
+        $dir_path = __DIR__ . "/../../deployment/custom_user_mappings";
         if (!is_dir($dir_path)) {
             throw new \Exception("custom_user_mappings directory '$dir_path' is not a directory");
         }

--- a/test/deployment/custom_user_mappings/phpunit.csv
+++ b/test/deployment/custom_user_mappings/phpunit.csv
@@ -1,6 +1,0 @@
-user2002_org998_test,555
-foobar0,1000000
-foobar1,1000001
-foobar2,1000002
-foobar3,1000003
-foobar4,1000004

--- a/test/deployment/domain_overrides/phpunit/config.ini
+++ b/test/deployment/domain_overrides/phpunit/config.ini
@@ -1,6 +1,3 @@
-[ldap]
-custom_user_mappings_dir = "test/deployment/custom_user_mappings"
-
 [site]
 allow_die = false
 enable_verbose_error_log = false

--- a/tools/docker-dev/build.sh
+++ b/tools/docker-dev/build.sh
@@ -5,7 +5,7 @@ trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 cd "$(dirname "$0")"
 
 # docker won't let you copy files from the parent directory of the dockerfile
-# one workaround is to use the `context` option in docker compose
+# another possible workaround is to use the `context` option in docker compose
 cp ../../composer.json web/composer.json
 cp ../../composer.lock web/composer.lock
 cp ../../package.json web/package.json

--- a/tools/docker-dev/build.sh
+++ b/tools/docker-dev/build.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
-set -e
+set -euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+
 cd "$(dirname "$0")"
+
+# docker won't let you copy files from the parent directory of the dockerfile
+# one workaround is to use the `context` option in docker compose
+cp ../../composer.json web/composer.json
+cp ../../composer.lock web/composer.lock
+cp ../../package.json web/package.json
+cp ../../package-lock.json web/package-lock.json
+
 docker compose down
 docker compose build
 # docker image prune

--- a/tools/docker-dev/docker-compose.yml
+++ b/tools/docker-dev/docker-compose.yml
@@ -39,14 +39,8 @@ services:
     ports:
       - "127.0.0.1:8000:80"
     volumes:
-      - ../../composer.json:/srv/www/unity-web/composer.json
-      - ../../composer.lock:/srv/www/unity-web/composer.lock
-      - ../../package.json:/srv/www/unity-web/package.json
-      - ../../package-lock.json:/srv/www/unity-web/package-lock.json
-      - ../../phpstan.neon:/srv/www/unity-web/phpstan.neon
       - ../../phpunit.xml:/srv/www/unity-web/phpunit.xml
       - ../../resources:/srv/www/unity-web/resources
-      # - ../../.git/modules/hakasapl/phpopenldaper/src/PHPOpenLDAPer:/srv/www/unity-web/resources/lib/phpopenldaper/src/PHPOpenLDAPer
       - ../../test:/srv/www/unity-web/test
       - ../../webroot:/srv/www/unity-web/webroot
       - ../../workers:/srv/www/unity-web/workers

--- a/tools/docker-dev/docker-compose.yml
+++ b/tools/docker-dev/docker-compose.yml
@@ -39,18 +39,32 @@ services:
     ports:
       - "127.0.0.1:8000:80"
     volumes:
-      - ../../:/var/www/unity-web-portal
-      - ../../test/deployment/domain_overrides/phpunit:/var/www/unity-web-portal/deployment/domain_overrides/phpunit
+      - ../../composer.json:/srv/www/unity-web/composer.json
+      - ../../composer.lock:/srv/www/unity-web/composer.lock
+      - ../../package.json:/srv/www/unity-web/package.json
+      - ../../package-lock.json:/srv/www/unity-web/package-lock.json
+      - ../../phpstan.neon:/srv/www/unity-web/phpstan.neon
+      - ../../phpunit.xml:/srv/www/unity-web/phpunit.xml
+      - ../../resources:/srv/www/unity-web/resources
+      # - ../../.git/modules/hakasapl/phpopenldaper/src/PHPOpenLDAPer:/srv/www/unity-web/resources/lib/phpopenldaper/src/PHPOpenLDAPer
+      - ../../test:/srv/www/unity-web/test
+      - ../../webroot:/srv/www/unity-web/webroot
+      - ../../workers:/srv/www/unity-web/workers
+      - ../../deployment/config.base.ini:/srv/www/unity-web/deployment/config.base.ini
+      - ../../test/deployment/custom_user_mappings:/srv/www/unity-web/deployment/custom_user_mappings
+      - ../../deployment/domain_overrides/course-creator:/srv/www/unity-web/deployment/domain_overrides/course-creator
+      - ../../deployment/domain_overrides/worker:/srv/www/unity-web/deployment/domain_overrides/worker
+      - ../../test/deployment/domain_overrides/phpunit:/srv/www/unity-web/deployment/domain_overrides/phpunit
       # docker doesn't like how these paths have colons in them
       # https://github.com/docker/compose/issues/12553#issuecomment-2656090965
       - type: bind
         source: ../../test/deployment/domain_overrides/account-portal-docker-web-green:8000
-        target: /var/www/unity-web-portal/deployment/domain_overrides/account-portal-docker-web-green:8000
+        target: /srv/www/unity-web/deployment/domain_overrides/account-portal-docker-web-green:8000
         bind:
           create_host_path: false
       - type: bind
         source: ../../test/deployment/domain_overrides/account-portal-docker-web:8000
-        target: /var/www/unity-web-portal/deployment/domain_overrides/account-portal-docker-web:8000
+        target: /srv/www/unity-web/deployment/domain_overrides/account-portal-docker-web:8000
         bind:
           create_host_path: false
     depends_on:

--- a/tools/docker-dev/identity/Dockerfile
+++ b/tools/docker-dev/identity/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:24.04
 
 # OpenLDAP Server
 ARG DEBIAN_FRONTEND=noninteractive
+RUN sed -i 's/ports.ubuntu.com/mirrors.ocf.berkeley.edu/' /etc/apt/sources.list.d/ubuntu.sources
 RUN apt-get update && apt-get install -y \
     slapd \
     ldap-utils \

--- a/tools/docker-dev/run.sh
+++ b/tools/docker-dev/run.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
-set -e
+set -euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+
 cd "$(dirname "$0")"
 docker compose up

--- a/tools/docker-dev/sql/Dockerfile
+++ b/tools/docker-dev/sql/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
+RUN sed -i 's/ports.ubuntu.com/mirrors.ocf.berkeley.edu/' /etc/apt/sources.list.d/ubuntu.sources
 RUN apt-get update && apt-get install -y \
     mariadb-server \
     mariadb-client \

--- a/tools/docker-dev/web/.gitignore
+++ b/tools/docker-dev/web/.gitignore
@@ -1,0 +1,4 @@
+composer.json
+composer.lock
+package.json
+package-lock.json

--- a/tools/docker-dev/web/Dockerfile
+++ b/tools/docker-dev/web/Dockerfile
@@ -4,19 +4,17 @@ FROM ubuntu:24.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN sed -i 's/ports.ubuntu.com/mirrors.ocf.berkeley.edu/' /etc/apt/sources.list.d/ubuntu.sources
-RUN apt-get update
-RUN apt-get install -y wget gnupg ca-certificates
 
-# I would use ADD but ADD always invalidates the cache, I don't really care about this getting stale
-RUN wget https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key -O /tmp/nodesource-repo.gpg.key
-RUN mkdir -p /etc/apt/keyrings && \
-    gpg --dearmor --yes --output /etc/apt/keyrings/node.asc /tmp/nodesource-repo.gpg.key && \
-    chmod a+r /etc/apt/keyrings/node.asc
+# I would use ADD to download the key but ADD always invalidates the cache
+# I don't really care about this getting stale
 COPY node.sources /etc/apt/sources.list.d/node.sources
-RUN apt-get update
+RUN apt-get update && apt-get install -y wget gnupg ca-certificates && \
+    wget https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key -O /tmp/nodesource-repo.gpg.key && \
+    mkdir -p /etc/apt/keyrings && \
+    gpg --dearmor --yes --output /etc/apt/keyrings/node.asc /tmp/nodesource-repo.gpg.key
 
 # php extensions also listed in .github/workflows/phpunit.yml and README.md
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
     apache2 \
     apache2-utils \
     php \

--- a/tools/docker-dev/web/Dockerfile
+++ b/tools/docker-dev/web/Dockerfile
@@ -2,8 +2,20 @@ FROM ubuntu:24.04
 
 # Web Server Setup
 ARG DEBIAN_FRONTEND=noninteractive
+
+RUN sed -i 's/ports.ubuntu.com/mirrors.ocf.berkeley.edu/' /etc/apt/sources.list.d/ubuntu.sources
+RUN apt-get update
+RUN apt-get install -y gnupg ca-certificates
+
+ADD https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key /tmp/nodesource-repo.gpg.key
+RUN mkdir -p /etc/apt/keyrings && \
+    gpg --dearmor --yes --output /etc/apt/keyrings/node.asc /tmp/nodesource-repo.gpg.key && \
+    chmod a+r /etc/apt/keyrings/node.asc
+COPY node.sources /etc/apt/sources.list.d/node.sources
+RUN apt-get update
+
 # php extensions also listed in .github/workflows/phpunit.yml and README.md
-RUN apt-get update && apt-get install -y \
+RUN apt-get install -y \
     apache2 \
     apache2-utils \
     php \
@@ -15,7 +27,9 @@ RUN apt-get update && apt-get install -y \
     php-mbstring \
     php-xml \
     php-intl \
-    php-xdebug
+    php-xdebug \
+    composer \
+    nodejs
 COPY htpasswd /etc/apache2/.htpasswd
 RUN chown www-data /etc/apache2/.htpasswd
 COPY unity-apache.conf /etc/apache2/sites-available/unity.conf
@@ -31,6 +45,17 @@ RUN sed -i '/zend.exception_ignore_args/c\zend.exception_ignore_args = 0' /etc/p
 RUN sed -i '/zend.exception_ignore_args/c\zend.exception_ignore_args = 0' /etc/php/8.3/cli/php.ini
 RUN echo 'xdebug.mode=develop,coverage,debug,gcstats,profile,trace' >> /etc/php/8.3/cli/php.ini
 RUN echo 'xdebug.mode=develop,coverage,debug,gcstats,profile,trace' >> /etc/php/8.3/apache2/php.ini
+
+RUN mkdir -p /srv/www/unity-web
+
+COPY composer.json /srv/www/unity-web/composer.json
+COPY composer.lock /srv/www/unity-web/composer.lock
+RUN cd /srv/www/unity-web && COMPOSER_ALLOW_SUPERUSER=1 composer --no-dev --no-scripts --no-plugins install
+
+COPY package.json /srv/www/unity-web/package.json
+COPY package-lock.json /srv/www/unity-web/package-lock.json
+RUN cd /srv/www/unity-web && npm install
+RUN cd /srv/www/unity-web && npx copy-files-from-to
 
 # Start apache2 server
 EXPOSE 80

--- a/tools/docker-dev/web/Dockerfile
+++ b/tools/docker-dev/web/Dockerfile
@@ -5,9 +5,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN sed -i 's/ports.ubuntu.com/mirrors.ocf.berkeley.edu/' /etc/apt/sources.list.d/ubuntu.sources
 RUN apt-get update
-RUN apt-get install -y gnupg ca-certificates
+RUN apt-get install -y wget gnupg ca-certificates
 
-ADD https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key /tmp/nodesource-repo.gpg.key
+# I would use ADD but ADD always invalidates the cache, I don't really care about this getting stale
+RUN wget https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key -O /tmp/nodesource-repo.gpg.key
 RUN mkdir -p /etc/apt/keyrings && \
     gpg --dearmor --yes --output /etc/apt/keyrings/node.asc /tmp/nodesource-repo.gpg.key && \
     chmod a+r /etc/apt/keyrings/node.asc

--- a/tools/docker-dev/web/Dockerfile
+++ b/tools/docker-dev/web/Dockerfile
@@ -50,7 +50,7 @@ RUN mkdir -p /srv/www/unity-web
 
 COPY composer.json /srv/www/unity-web/composer.json
 COPY composer.lock /srv/www/unity-web/composer.lock
-RUN cd /srv/www/unity-web && COMPOSER_ALLOW_SUPERUSER=1 composer --no-dev --no-scripts --no-plugins install
+RUN cd /srv/www/unity-web && COMPOSER_ALLOW_SUPERUSER=1 composer --dev --no-scripts --no-plugins install
 
 COPY package.json /srv/www/unity-web/package.json
 COPY package-lock.json /srv/www/unity-web/package-lock.json

--- a/tools/docker-dev/web/node.sources
+++ b/tools/docker-dev/web/node.sources
@@ -1,0 +1,8 @@
+Architectures: amd64 arm64
+Components: main
+X-Repolib-Name: node
+Signed-By: /etc/apt/keyrings/node.asc
+Suites: nodistro
+Trusted: yes
+Types: deb
+URIs: https://deb.nodesource.com/node_24.x

--- a/tools/docker-dev/web/unity-apache.conf
+++ b/tools/docker-dev/web/unity-apache.conf
@@ -1,5 +1,5 @@
 <VirtualHost _default_:80>
-    DocumentRoot /var/www/unity-web-portal/webroot
+    DocumentRoot /srv/www/unity-web/webroot
     <LocationMatch '^/(panel|admin)'>
         AuthType Basic
         AuthName "Unity User Panel"

--- a/tools/docker-dev/web/unity-apache.conf
+++ b/tools/docker-dev/web/unity-apache.conf
@@ -1,7 +1,10 @@
 <VirtualHost _default_:80>
     DocumentRoot /srv/www/unity-web/webroot
+    <Directory /srv/www/unity-web/webroot>
+        AuthType basic
+        Require all granted
+    </Directory>
     <LocationMatch '^/(panel|admin)'>
-        AuthType Basic
         AuthName "Unity User Panel"
         AuthUserFile /etc/apache2/.htpasswd
         Require valid-user
@@ -11,8 +14,6 @@
     </LocationMatch>
     <Location /lan>
         # in production you should require an address in your LAN, example "Require ip 10.0.0.0/8"
-        AuthType basic
-        Require all granted
         CGIPassAuth On
     </Location>
 </VirtualHost>


### PR DESCRIPTION
* run `composer install --dev`, `npm install` in the container
    * `composer install --dev` still encouraged on your local machine for your IDE
    * `npm install --dev` still required on your local machine for `prettier-plugin-php`
    * this should result in a slight speedup of the github CI, since `composer install --dev` is now cached
* run `npx copy-files-from-to` in the container
    * no longer required on your local machine
* bind-mount only the necessary files and directories into the docker container
    * this was required so that `vendor`, `node_modules` are not bind mounted
* copy `package{-lock,}.json`, `composer.{lock,json}` into the container at build time, also copy the files into `tools/docker-dev/web/` before building, gitignore new copies
    * this was required because bind mounts don't take place until runtime, and a dockerfile can't reference files in parent directories
* move the files from `/var/www/unity-web-portal` to `/srv/www/unity-web` in the container
    * to match production
* change the apt source from `ports.ubuntu.com` to UC Berkeley mirror
    * only applies when arch != x86_64
    * `ports.ubuntu.com` seems to be down today
* remove `custom_user_mappings_dir` config, since `test/custom_user_mappings` is now bind-mounted into the container to `deployment/custom_user_mappings`
* remove duplicate custom user mappings file