### PR TITLE
optimize CI

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -20,6 +20,8 @@ jobs:
           echo "REPO_OWNER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -32,14 +34,12 @@ jobs:
             --tag docker-dev-identity \
             --cache-from type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/unity-dev-identity:buildcache \
             --cache-to type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/unity-dev-identity:buildcache,mode=max \
-            --load \
             ./tools/docker-dev/identity
 
           docker buildx build \
             --tag docker-dev-sql \
             --cache-from type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/unity-dev-sql:buildcache \
             --cache-to type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/unity-dev-sql:buildcache,mode=max \
-            --load \
             ./tools/docker-dev/sql
 
           cp package{-lock,}.json tools/docker-dev/web/
@@ -48,7 +48,6 @@ jobs:
             --tag docker-dev-web \
             --cache-from type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/unity-dev-web:buildcache \
             --cache-to type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/unity-dev-web:buildcache,mode=max \
-            --load \
             ./tools/docker-dev/web
       - run: docker compose -f ./tools/docker-dev/docker-compose.yml up -d --no-build
       - run: docker compose -f ./tools/docker-dev/docker-compose.yml exec -w '/srv/www/unity-web' web bash -c 'XDEBUG_MODE=coverage ./vendor/bin/phpunit --coverage-clover="$(mktemp --suffix=.xml)" -d --min-coverage=./coverage.php'

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -28,26 +28,9 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build docker-compose images with cache
+      - name: Prepare web build context
         run: |
-          docker buildx build \
-            --tag docker-dev-identity \
-            --cache-from type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/unity-dev-identity:buildcache \
-            --cache-to type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/unity-dev-identity:buildcache,mode=max \
-            ./tools/docker-dev/identity
-
-          docker buildx build \
-            --tag docker-dev-sql \
-            --cache-from type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/unity-dev-sql:buildcache \
-            --cache-to type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/unity-dev-sql:buildcache,mode=max \
-            ./tools/docker-dev/sql
-
           cp package{-lock,}.json tools/docker-dev/web/
           cp composer.{json,lock} tools/docker-dev/web/
-          docker buildx build \
-            --tag docker-dev-web \
-            --cache-from type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/unity-dev-web:buildcache \
-            --cache-to type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/unity-dev-web:buildcache,mode=max \
-            ./tools/docker-dev/web
-      - run: docker compose -f ./tools/docker-dev/docker-compose.yml up -d --no-build
+      - run: COMPOSE_BAKE=true docker compose -f ./tools/docker-dev/docker-compose.yml up -d --build
       - run: docker compose -f ./tools/docker-dev/docker-compose.yml exec -w '/srv/www/unity-web' web bash -c 'XDEBUG_MODE=coverage ./vendor/bin/phpunit --coverage-clover="$(mktemp --suffix=.xml)" -d --min-coverage=./coverage.php'

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -29,32 +29,26 @@ jobs:
       - name: Build docker-compose images with cache
         run: |
           docker buildx build \
-            --tag ghcr.io/${{ env.REPO_OWNER }}/unity-dev-identity:latest \
+            --tag docker-dev-identity \
             --cache-from type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/unity-dev-identity:buildcache \
             --cache-to type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/unity-dev-identity:buildcache,mode=max \
+            --load \
             ./tools/docker-dev/identity
 
           docker buildx build \
-            --tag ghcr.io/${{ env.REPO_OWNER }}/unity-dev-sql:latest \
+            --tag docker-dev-sql \
             --cache-from type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/unity-dev-sql:buildcache \
             --cache-to type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/unity-dev-sql:buildcache,mode=max \
+            --load \
             ./tools/docker-dev/sql
 
           cp package{-lock,}.json tools/docker-dev/web/
           cp composer.{json,lock} tools/docker-dev/web/
           docker buildx build \
-            --tag ghcr.io/${{ env.REPO_OWNER }}/unity-dev-web:latest \
+            --tag docker-dev-web \
             --cache-from type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/unity-dev-web:buildcache \
             --cache-to type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/unity-dev-web:buildcache,mode=max \
+            --load \
             ./tools/docker-dev/web
-
-      - name: Pull cache images to local Docker
-        run: |
-          docker pull ghcr.io/${{ env.REPO_OWNER }}/unity-dev-identity:latest
-          docker tag ghcr.io/${{ env.REPO_OWNER }}/unity-dev-identity:latest docker-dev-identity
-          docker pull ghcr.io/${{ env.REPO_OWNER }}/unity-dev-sql:latest
-          docker tag ghcr.io/${{ env.REPO_OWNER }}/unity-dev-sql:latest docker-dev-sql
-          docker pull ghcr.io/${{ env.REPO_OWNER }}/unity-dev-web:latest
-          docker tag ghcr.io/${{ env.REPO_OWNER }}/unity-dev-web:latest docker-dev-web
       - run: docker compose -f ./tools/docker-dev/docker-compose.yml up -d --no-build
       - run: docker compose -f ./tools/docker-dev/docker-compose.yml exec -w '/srv/www/unity-web' web bash -c 'XDEBUG_MODE=coverage ./vendor/bin/phpunit --coverage-clover="$(mktemp --suffix=.xml)" -d --min-coverage=./coverage.php'

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -20,8 +20,6 @@ jobs:
           echo "REPO_OWNER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          driver: docker-container
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -32,14 +32,12 @@ jobs:
             --tag ghcr.io/${{ env.REPO_OWNER }}/unity-dev-identity:latest \
             --cache-from type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/unity-dev-identity:buildcache \
             --cache-to type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/unity-dev-identity:buildcache,mode=max \
-            --push \
             ./tools/docker-dev/identity
 
           docker buildx build \
             --tag ghcr.io/${{ env.REPO_OWNER }}/unity-dev-sql:latest \
             --cache-from type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/unity-dev-sql:buildcache \
             --cache-to type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/unity-dev-sql:buildcache,mode=max \
-            --push \
             ./tools/docker-dev/sql
 
           cp package{-lock,}.json tools/docker-dev/web/
@@ -48,7 +46,6 @@ jobs:
             --tag ghcr.io/${{ env.REPO_OWNER }}/unity-dev-web:latest \
             --cache-from type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/unity-dev-web:buildcache \
             --cache-to type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/unity-dev-web:buildcache,mode=max \
-            --push \
             ./tools/docker-dev/web
 
       - name: Pull cache images to local Docker

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -26,9 +26,11 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Prepare web build context
+      - name: Prepare build context
         run: |
           cp package{-lock,}.json tools/docker-dev/web/
           cp composer.{json,lock} tools/docker-dev/web/
-      - run: COMPOSE_BAKE=true docker compose -f ./tools/docker-dev/docker-compose.yml up -d --build
-      - run: docker compose -f ./tools/docker-dev/docker-compose.yml exec -w '/srv/www/unity-web' web bash -c 'XDEBUG_MODE=coverage ./vendor/bin/phpunit --coverage-clover="$(mktemp --suffix=.xml)" -d --min-coverage=./coverage.php'
+          cd tools/docker-dev
+          python ./generate-github-ci-docker-compose.py > github-ci-docker-compose.yml
+      - run: COMPOSE_BAKE=true docker compose -f ./tools/docker-dev/github-ci-docker-compose.yml up -d --build
+      - run: docker compose -f ./tools/docker-dev/github-ci-docker-compose.yml exec -w '/srv/www/unity-web' web bash -c 'XDEBUG_MODE=coverage ./vendor/bin/phpunit --coverage-clover="$(mktemp --suffix=.xml)" -d --min-coverage=./coverage.php'

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+      # https://github.com/orgs/community/discussions/25768
       - name: Convert variables to lowercase
         run: |
           echo "REPO_OWNER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV

--- a/tools/docker-dev/docker-compose.yml
+++ b/tools/docker-dev/docker-compose.yml
@@ -4,12 +4,7 @@ networks:
 services:
   identity:
     hostname: identity
-    build:
-      context: identity
-      cache_from:
-        - type=registry,ref=ghcr.io/${REPO_OWNER}/unity-dev-identity:buildcache
-      cache_to:
-        - type=registry,ref=ghcr.io/${REPO_OWNER}/unity-dev-identity:buildcache,mode=max
+    build: identity
     ports:
       - "127.0.0.1:8010:80"
       - "127.0.0.1:389:389"
@@ -22,12 +17,7 @@ services:
       interval: 1s
   sql:
     hostname: sql
-    build:
-      context: sql
-      cache_from:
-        - type=registry,ref=ghcr.io/${REPO_OWNER}/unity-dev-sql:buildcache
-      cache_to:
-        - type=registry,ref=ghcr.io/${REPO_OWNER}/unity-dev-sql:buildcache,mode=max
+    build: sql
     ports:
       - "127.0.0.1:8020:80"
       - "127.0.0.1:3306:3306"
@@ -45,12 +35,7 @@ services:
       - "127.0.0.1:8030:1080"
   web:
     hostname: web
-    build:
-      context: web
-      cache_from:
-        - type=registry,ref=ghcr.io/${REPO_OWNER}/unity-dev-web:buildcache
-      cache_to:
-        - type=registry,ref=ghcr.io/${REPO_OWNER}/unity-dev-web:buildcache,mode=max
+    build: web
     ports:
       - "127.0.0.1:8000:80"
     volumes:

--- a/tools/docker-dev/docker-compose.yml
+++ b/tools/docker-dev/docker-compose.yml
@@ -4,7 +4,12 @@ networks:
 services:
   identity:
     hostname: identity
-    build: identity
+    build:
+      context: identity
+      cache_from:
+        - type=registry,ref=ghcr.io/${REPO_OWNER}/unity-dev-identity:buildcache
+      cache_to:
+        - type=registry,ref=ghcr.io/${REPO_OWNER}/unity-dev-identity:buildcache,mode=max
     ports:
       - "127.0.0.1:8010:80"
       - "127.0.0.1:389:389"
@@ -17,7 +22,12 @@ services:
       interval: 1s
   sql:
     hostname: sql
-    build: sql
+    build:
+      context: sql
+      cache_from:
+        - type=registry,ref=ghcr.io/${REPO_OWNER}/unity-dev-sql:buildcache
+      cache_to:
+        - type=registry,ref=ghcr.io/${REPO_OWNER}/unity-dev-sql:buildcache,mode=max
     ports:
       - "127.0.0.1:8020:80"
       - "127.0.0.1:3306:3306"
@@ -35,7 +45,12 @@ services:
       - "127.0.0.1:8030:1080"
   web:
     hostname: web
-    build: web
+    build:
+      context: web
+      cache_from:
+        - type=registry,ref=ghcr.io/${REPO_OWNER}/unity-dev-web:buildcache
+      cache_to:
+        - type=registry,ref=ghcr.io/${REPO_OWNER}/unity-dev-web:buildcache,mode=max
     ports:
       - "127.0.0.1:8000:80"
     volumes:

--- a/tools/docker-dev/generate-github-ci-docker-compose.py
+++ b/tools/docker-dev/generate-github-ci-docker-compose.py
@@ -1,0 +1,28 @@
+import yaml
+
+"""
+update docker-compose.yml to specify caching strategy for github CI
+"""
+
+with open("docker-compose.yml", "r") as f:
+    data = yaml.safe_load(f)
+for service_name, service_data in data["services"].items():
+    if "build" not in service_data:
+        continue
+    old_build = service_data["build"]
+    assert isinstance(old_build, str), (
+        f"expected string (example: 'web', 'sql', 'identity'), found: {old_build}"
+    )
+    new_build = dict(
+        context=old_build,
+        cache_from=[
+            r"type=registry,ref=ghcr.io/${REPO_OWNER}/unity-dev-%s:buildcache" % (old_build)
+        ],
+        cache_to=[
+            r"type=registry,ref=ghcr.io/${REPO_OWNER}/unity-dev-%s:buildcache,mode=max"
+            % (old_build)
+        ],
+    )
+    data["services"][service_name]["build"] = new_build
+
+print(yaml.safe_dump(data, sort_keys=False))


### PR DESCRIPTION
reduces the container building phase to 26 seconds (if you're lucky)

for reference, the relevant portion of [the last pipeline on the main branch](https://github.com/UnityHPC/account-portal/actions/runs/29439731473/job/87440495931) took 11 + 27 seconds

The previous workflow used `docker buildx build --push` (to build the images and upload them back to the container registry) followed by `docker pull` (to download the images from the container registry and load them into the local docker daemon) followed by `docker compose up`. The new workflow just uses `docker compose up`. When using `bake`, you are able to specify `cache_from` and `cache_to` in the `docker-compose.yml`. I have a python script to create a modified version of the `docker-compose.yml` when the CI runs to add these parameters.

Note: I tried `docker buildx build --load`, but the tarball overhead took up much more time than uploading & downloading again.