### PR TITLE
prettier permission denied

### DIFF
--- a/resources/lib/UnityHTTPD.php
+++ b/resources/lib/UnityHTTPD.php
@@ -99,12 +99,9 @@ class UnityHTTPD
             }
             // text may not be shown in the webpage in an obvious way, so make a popup
             self::alert(implode(" -- ", [$title, ...$body_paragraphs]));
-            echo sprintf(
-                "<h1>%s</h1>\n%s\n<br>\n<a href='%s'>Go to Home</a>",
-                htmlspecialchars($title),
-                implode("\n<br>\n", $body_paragraphs),
-                getRelativeURL("/index.php"),
-            );
+            printf("<h1>%s</h1>\n", htmlspecialchars($title));
+            printf("%s\n<br>\n", implode("\n<br>\n", $body_paragraphs));
+            printf("<a href='%s'>Go to Home</a>\n<br>\n", getRelativeURL("/index.php"));
             // display_errors should not be enabled in production
             if (
                 !is_null($error) &&

--- a/resources/lib/UnityHTTPD.php
+++ b/resources/lib/UnityHTTPD.php
@@ -100,7 +100,9 @@ class UnityHTTPD
             // text may not be shown in the webpage in an obvious way, so make a popup
             self::alert(implode(" -- ", [$title, ...$body_paragraphs]));
             printf("<h1>%s</h1>\n", htmlspecialchars($title));
-            printf("%s\n<br>\n", implode("\n<br>\n", $body_paragraphs));
+            foreach ($body_paragraphs as $p) {
+                printf("%s\n<br>\n", htmlspecialchars($p));
+            }
             printf("<a href='%s'>Go to Home</a>\n<br>\n", getRelativeURL("/index.php"));
             // display_errors should not be enabled in production
             if (

--- a/resources/lib/UnityHTTPD.php
+++ b/resources/lib/UnityHTTPD.php
@@ -100,9 +100,10 @@ class UnityHTTPD
             // text may not be shown in the webpage in an obvious way, so make a popup
             self::alert(implode(" -- ", [$title, ...$body_paragraphs]));
             echo sprintf(
-                "<h1>%s</h1>\n%s\n",
+                "<h1>%s</h1>\n%s\n<br>\n<a href='%s'>Go to Home</a>",
                 htmlspecialchars($title),
                 implode("\n<br>\n", $body_paragraphs),
+                getRelativeURL("/index.php"),
             );
             // display_errors should not be enabled in production
             if (

--- a/webroot/panel/pi.php
+++ b/webroot/panel/pi.php
@@ -20,7 +20,7 @@ if (($gid = $_GET["gid"] ?? null) !== null) {
     $group = $USER->getPIGroup();
     $user_is_owner = true;
     if (!$group->exists()) {
-        UnityHTTPD::badRequest("not a PI", "You are not a PI.");
+        UnityHTTPD::forbidden("not a PI", "You are not a PI.");
     }
 }
 


### PR DESCRIPTION
<img width="520" height="144" alt="image" src="https://github.com/user-attachments/assets/8b77cd33-a1c1-4c9c-917a-875e148dc9f5" />

`pi.php` sends "bad request" when the user is not a PI when it should be sending "forbidden".

I considered making "permission denied" send a message and make the browser redirect back to home, but this seems unnecessarily confusing to the user. If they click a link and get permission denied and get teleported back to the home page, they don't even know what page was it that they got permission denied from. Instead let them see the "permission denied" message on the correct page, and provide them a hyperlink to the home page.